### PR TITLE
ci: improve PR workflow and add Codecov test results

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,57 +1,48 @@
 name: Pull Request Validation
 
 on:
-  push:
-    branches:
-    - renovate/**
   pull_request:
     branches:
     - main
     - develop
-  pull_request_target:  # For PR title validation
     types:
     - opened
     - edited
     - synchronize
+    - reopened
 
 jobs:
-  check-pr-title:
-    name: Check PR Title
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
-    permissions:
-      pull-requests: read
-    steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            docs
-            style
-            refactor
-            perf
-            test
-            build
-            ci
-            chore
-            revert
-          requireScope: false
-          subjectPattern: ^[a-z].+[^.]$   # must start lowercase, no period
-          validateSingleCommit: true       # also check lone commit if PR has only one
-
   validate:
     name: Validate
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request_target'
     strategy:
       matrix:
         python-version: ["3.13", "3.14"]
       fail-fast: false
 
     steps:
+    # PR title check (safe - no shell interpolation of untrusted input)
+    - name: Check PR Title
+      uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        types: |
+          feat
+          fix
+          docs
+          style
+          refactor
+          perf
+          test
+          build
+          ci
+          chore
+          revert
+        requireScope: false
+        subjectPattern: ^[a-z].+[^.]$
+        validateSingleCommit: true
+
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
     - name: Setup Python and uv
@@ -79,7 +70,6 @@ jobs:
   validate-docs:
     name: Validate Docs
     runs-on: ubuntu-24.04
-    if: github.event_name != 'pull_request_target'
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,13 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          uv run pytest --cov=hother.streamblocks --cov-report=term-missing --cov-report=html --cov-report=xml --cov-report=json
+          uv run pytest --cov=hother.streamblocks --cov-report=term-missing --cov-report=html --cov-report=xml --cov-report=json --junitxml=junit.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
@@ -45,5 +51,6 @@ jobs:
             htmlcov/
             coverage.xml
             coverage.json
+            junit.xml
             .coverage/
           retention-days: 30


### PR DESCRIPTION
## Summary

- Remove `push` trigger for renovate branches from PR workflow
- Remove `pull_request_target` (security improvement - avoids elevated permissions)
- Add `types` to `pull_request` trigger for PR title validation events
- Move PR title check into validate job (runs before checkout, safe - no shell interpolation)
- Add `codecov/test-results-action@v1` for test analytics on main branch
- Add `--junitxml=junit.xml` output to pytest

## Test plan

- [ ] Verify PR workflow triggers on pull_request events
- [ ] Verify PR title validation works
- [ ] Verify Codecov receives test results after merge to main