### PR TITLE
fix(ci): pin Python version in uv sync commands

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -40,9 +40,9 @@ runs:
       shell: bash
       run: |
         if [ -z "${{ inputs.dependency-groups }}" ]; then
-          uv sync
+          uv sync --python ${{ inputs.python-version }}
         elif [ "${{ inputs.dependency-groups }}" == "all" ]; then
-          uv sync --all-extras --dev
+          uv sync --python ${{ inputs.python-version }} --all-extras --dev
         else
-          uv sync --group ${{ inputs.dependency-groups }}
+          uv sync --python ${{ inputs.python-version }} --group ${{ inputs.dependency-groups }}
         fi


### PR DESCRIPTION
## Summary

- Add `--python` flag to all `uv sync` commands in setup-python-uv action
- Ensures virtual environment uses explicitly installed Python version
- Fixes build failures when uv auto-detects Python 3.14 (pydantic-core incompatible)

## Problem

The `validate-docs` job was failing because:
1. `uv python install 3.13` installs Python 3.13
2. `uv sync --group doc` was using Python 3.14 (auto-detected by uv)
3. pydantic-core doesn't have pre-built wheels for Python 3.14
4. Source build fails: PyO3 max supported version is 3.13

## Test plan

- [ ] Verify PR validation workflow passes
- [ ] Verify docs build succeeds with Python 3.13