### PR TITLE
fix: create namespace package init with pkgutil.extend_path

### DIFF
--- a/src/hother/__init__.py
+++ b/src/hother/__init__.py
@@ -1,0 +1,2 @@
+# Namespace package
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)


### PR DESCRIPTION
## Summary

Creates the missing `hother/__init__.py` file to properly support Python namespace packages.

## Changes

- Create `src/hother/__init__.py` with `pkgutil.extend_path()` call
- This enables packages like `hother.streamblocks`, `hother.cancelable`, and `hother.reactive_agent` to coexist

## Technical Details

The `hother/__init__.py` file was completely missing from this repository. Without it and the `pkgutil.extend_path()` call, only the last installed package in the `hother` namespace is accessible, causing `ModuleNotFoundError` when trying to import other packages in the namespace.

**New file:**
```python
# Namespace package
__path__ = __import__("pkgutil").extend_path(__path__, __name__)
```

## Testing

- All pre-commit hooks pass
- Local testing confirms namespace packages work correctly after this fix

## Impact

This is a critical fix for the hother namespace package ecosystem. It enables proper installation of multiple hother-* packages.

## Related

- hotherio/cancelable#11 (same fix for cancelable)