### PR TITLE
refactor(core): typed exception hierarchy, remove all type:ignore, IGL dev-infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -345,13 +345,3 @@ sandbox/
 
 # Auto Claude data directory
 .auto-claude/
-
-# ICML/BFCL benchmark datasets and prompt-comparison artifacts (research scratch,
-# kept out of the repo root; move large data under sandbox/ instead)
-/simple.json
-/multiple.json
-/parallel.json
-/parallel_multiple.json
-/relevance.json
-/irrelevance.json
-/prompt_comparison/

--- a/.gitignore
+++ b/.gitignore
@@ -345,3 +345,13 @@ sandbox/
 
 # Auto Claude data directory
 .auto-claude/
+
+# ICML/BFCL benchmark datasets and prompt-comparison artifacts (research scratch,
+# kept out of the repo root; move large data under sandbox/ instead)
+/simple.json
+/multiple.json
+/parallel.json
+/parallel_multiple.json
+/relevance.json
+/irrelevance.json
+/prompt_comparison/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md
+
+Canonical engineering conventions for Streamblocks, for human contributors and AI
+agents alike. These are **enforced contracts**, not suggestions: most are checked by
+`basedpyright` strict, `ruff`, `lefthook`, and the 100%-coverage gate. If a rule blocks
+you, change the rule deliberately (and this file) rather than working around it.
+
+## Toolchain
+
+- **Package/dev manager:** `uv`. Run everything through `uv run <cmd>`.
+- **Python:** 3.13+ (basedpyright targets 3.14). Use modern syntax: PEP 695 generics
+  (`class Foo[T]:`, `type Alias = ...`), `X | None` unions, `StrEnum`.
+- **Type checker:** `basedpyright` in **strict** mode (`[tool.pyright]` in `pyproject.toml`).
+- **Linter/formatter:** `ruff` — 120-col lines, double quotes, ~38 rule groups.
+- **Hooks:** `lefthook`. **Build:** `hatchling`. **Docs:** MkDocs Material. **Releases:**
+  `python-semantic-release` driven by conventional commits.
+
+## Hard rules (contracts)
+
+1. **No `# type: ignore`, no `# noqa`.** If the type system fights you, fix the types,
+   restructure, or use a narrow `typing.cast(...)` with a one-line comment explaining
+   *why* the cast is sound. `reportUnnecessaryTypeIgnoreComment` is an error, so a stale
+   ignore fails CI anyway. (See `core/parsing.py`, `core/processor.py` for examples of
+   `cast` used to express genuinely dynamic behavior.)
+2. **No magic values in comparisons.** Name constants (e.g. `core/constants.py` `LIMITS`).
+3. **`__all__` is mandatory and exhaustive** in public modules, grouped by category with
+   comments (see `src/hother/streamblocks/__init__.py`).
+4. **Google-style docstrings** on public classes/functions, including a `Raises:` section
+   naming the exception type when one is raised.
+5. **100% branch coverage.** `fail_under = 100`. Cover new branches with tests; reserve
+   `# pragma: no cover` for genuinely unreachable internal guards, with a reason.
+6. **Conventional commits**, atomic. **Never** `git commit --no-verify`. **Never**
+   `git push` without being asked.
+
+## Typing
+
+- Annotate all public surfaces; `reportUnknownMemberType`/`reportUnknownParameterType`
+  are errors.
+- Prefer **Protocols** (`@runtime_checkable` where needed) over duck typing for
+  structural contracts (see `adapters/protocols.py`).
+- Put annotation-only imports under `if TYPE_CHECKING:` (with `from __future__ import
+  annotations`), so they don't run at import time.
+- `Any` is allowed only where genuinely unavoidable (heterogeneous registries, dynamic
+  descriptors); keep it contained and documented.
+
+## Errors: exceptions vs. events
+
+Two distinct channels — do not collapse them:
+
+- **`StreamblocksError` hierarchy** (`core/exceptions.py`) — raised **synchronously** for
+  programmer/configuration errors (adapter not configured, no adapter detected for a chunk
+  type, bad syntax argument). Flat subclasses with typed attributes and helpful messages.
+  Consumers `except StreamblocksError`.
+- **`BlockErrorEvent` / `BlockErrorCode`** (`core/types.py`) — emitted **as data into the
+  stream** for per-block runtime problems (validation failed, size exceeded, unclosed
+  block). These are not exceptions.
+
+When raising inside an `except`, chain with `raise NewError(...) from exc`.
+
+## Testing
+
+- `pytest` with `asyncio_mode = "auto"`; tests live in `tests/` mirroring `src/`.
+- The suite runs **shuffled** (`pytest-randomly`) and **in parallel** (`pytest-xdist -n
+  auto`) with `xfail_strict = true` — keep tests order-independent; fix leaks rather than
+  pinning a seed.
+- Property-based tests via `hypothesis` where it adds value.
+
+## Everyday commands
+
+```bash
+uv run lefthook run pre-commit --all-files -- --no-stash   # ruff + basedpyright + secrets
+uv run pytest                                              # shuffled, parallel, 100% cov gate
+uv run python src/hother/streamblocks_examples/run_examples.py   # all examples must pass
+uv run mkdocs serve                                        # preview docs
+```
+
+Always run lefthook **with** `--no-stash` (keeps your working changes in place).
+
+## Pull requests
+
+Branch off `main`, conventional-commit PR title, link the issue, ensure pre-commit +
+`pytest` + the example runner are green. See `docs/contributing.md` for the full workflow.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,11 @@
 
 Thank you for your interest in contributing to Streamblocks!
 
+> **Conventions:** see [`AGENTS.md`](https://github.com/hotherio/streamblocks/blob/main/AGENTS.md)
+> in the repository root for the canonical, enforced engineering conventions (typing,
+> error handling, testing, the no-`type: ignore`/no-magic-values contracts). This page
+> covers the day-to-day workflow.
+
 ## Development Setup
 
 1. **Clone the repository**:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,7 +340,6 @@ ignore = [
     "examples/blocks/agent/files.py",  # Literal narrowing for block_type
     "examples/blocks/agent/message.py",  # Literal narrowing for block_type
     "examples/blocks/agent/patch.py",  # Literal narrowing for block_type
-    "src/hother/streamblocks/adapters/detection.py",  # type(Any) returns type[Unknown]
     "src/hother/streamblocks/extensions/agui/output_adapter.py",  # Complex generic type interactions
     "src/hother/streamblocks/extensions/agui/input_adapter.py",  # ag_ui.core has no type stubs
     "src/hother/streamblocks/syntaxes/factory.py",  # Exhaustive match on StrEnum triggers reportUnnecessaryComparison

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,7 +333,7 @@ line-ending = "auto"
 max-complexity = 10
 
 # Type checking with basedpyright
-[tool.pyright]
+[tool.basedpyright]
 include = ["src", "examples"]
 exclude = ["**/__pycache__", "**/migrations", ".venv", "tests", "src/hother/streamblocks_examples"]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,7 +342,6 @@ ignore = [
     "examples/blocks/agent/patch.py",  # Literal narrowing for block_type
     "src/hother/streamblocks/extensions/agui/output_adapter.py",  # Complex generic type interactions
     "src/hother/streamblocks/extensions/agui/input_adapter.py",  # ag_ui.core has no type stubs
-    "src/hother/streamblocks/syntaxes/factory.py",  # Exhaustive match on StrEnum triggers reportUnnecessaryComparison
     # Block types use Literal narrowing for block_type which triggers reportIncompatibleVariableOverride
     "src/hother/streamblocks/blocks/patch.py",
     "src/hother/streamblocks/blocks/files.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,8 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=6.0",
     "pytest-asyncio>=0.21",
+    "pytest-randomly>=3.16",
+    "pytest-xdist>=3.6",
     "hypothesis>=6.0",
     "ruff>=0.8",
     "basedpyright>=1.36.2",
@@ -385,7 +387,11 @@ python_classes = "Test*"
 python_functions = "test_*"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+# Treat unexpected xpass as a failure so stale xfails surface.
+xfail_strict = true
 addopts = [
+    "-n",
+    "auto",
     "--cov=hother.streamblocks",
     "--cov-report=term-missing",
     "--cov-report=html",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -341,7 +341,6 @@ ignore = [
     "examples/blocks/agent/message.py",  # Literal narrowing for block_type
     "examples/blocks/agent/patch.py",  # Literal narrowing for block_type
     "src/hother/streamblocks/adapters/detection.py",  # type(Any) returns type[Unknown]
-    "src/hother/streamblocks/core/protocol_processor.py",  # Complex generic type interactions
     "src/hother/streamblocks/extensions/agui/output_adapter.py",  # Complex generic type interactions
     "src/hother/streamblocks/extensions/agui/input_adapter.py",  # ag_ui.core has no type stubs
     "src/hother/streamblocks/syntaxes/factory.py",  # Exhaustive match on StrEnum triggers reportUnnecessaryComparison

--- a/src/hother/streamblocks/__init__.py
+++ b/src/hother/streamblocks/__init__.py
@@ -16,6 +16,12 @@ from hother.streamblocks.adapters import (
     OutputProtocolAdapter,
     detect_input_adapter,
 )
+from hother.streamblocks.core.exceptions import (
+    AdapterDetectionError,
+    AdapterNotConfiguredError,
+    StreamblocksError,
+    SyntaxConfigError,
+)
 from hother.streamblocks.core.models import Block, BlockCandidate, ExtractedBlock
 from hother.streamblocks.core.parsing import ParseStrategy, parse_as_json, parse_as_yaml
 from hother.streamblocks.core.processor import StreamBlockProcessor, StreamState
@@ -56,6 +62,11 @@ from hother.streamblocks.syntaxes import (
 BlockEndEvent.model_rebuild()
 
 __all__ = [
+    # Exceptions
+    "AdapterDetectionError",
+    "AdapterNotConfiguredError",
+    "StreamblocksError",
+    "SyntaxConfigError",
     # Adapters (new bidirectional system)
     "BidirectionalAdapter",
     "EventCategory",

--- a/src/hother/streamblocks/adapters/detection.py
+++ b/src/hother/streamblocks/adapters/detection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, cast, runtime_checkable
 
 from hother.streamblocks.core.exceptions import AdapterDetectionError
 
@@ -205,7 +205,8 @@ def detect_input_adapter(sample: Any) -> InputProtocolAdapter[Any]:
     """
     adapter = InputAdapterRegistry.detect(sample)
     if adapter is None:
-        chunk_type = type(sample)
+        # sample is Any, so type(sample) is type[Unknown]; pin it to a known type.
+        chunk_type = cast("type[object]", type(sample))
         registered_modules = tuple(InputAdapterRegistry.get_registered_modules().keys())
         raise AdapterDetectionError(
             chunk_type=f"{chunk_type.__module__}.{chunk_type.__name__}",

--- a/src/hother/streamblocks/adapters/detection.py
+++ b/src/hother/streamblocks/adapters/detection.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
+from hother.streamblocks.core.exceptions import AdapterDetectionError
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -199,16 +201,14 @@ def detect_input_adapter(sample: Any) -> InputProtocolAdapter[Any]:
         Detected adapter instance
 
     Raises:
-        ValueError: If no adapter matches the sample
+        AdapterDetectionError: If no adapter matches the sample
     """
     adapter = InputAdapterRegistry.detect(sample)
     if adapter is None:
         chunk_type = type(sample)
-        registered_modules = list(InputAdapterRegistry.get_registered_modules().keys())
-        msg = (
-            f"No input adapter found for {chunk_type.__module__}.{chunk_type.__name__}. "
-            f"Registered module prefixes: {registered_modules}. "
-            f"Consider importing the appropriate extension or registering a custom adapter."
+        registered_modules = tuple(InputAdapterRegistry.get_registered_modules().keys())
+        raise AdapterDetectionError(
+            chunk_type=f"{chunk_type.__module__}.{chunk_type.__name__}",
+            registered_prefixes=registered_modules,
         )
-        raise ValueError(msg)
     return adapter

--- a/src/hother/streamblocks/adapters/protocols.py
+++ b/src/hother/streamblocks/adapters/protocols.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
 
-from hother.streamblocks.adapters.categories import EventCategory  # noqa: TC001 - needed at runtime for Protocol
-
 if TYPE_CHECKING:
+    from hother.streamblocks.adapters.categories import EventCategory
     from hother.streamblocks.core.types import BaseEvent
 
 TInput = TypeVar("TInput", contravariant=True)

--- a/src/hother/streamblocks/core/block_state_machine.py
+++ b/src/hother/streamblocks/core/block_state_machine.py
@@ -368,22 +368,24 @@ class BlockStateMachine:
     def _create_extracted_block(
         self,
         candidate: BlockCandidate,
-        parse_result: ParseResult[BaseMetadata, BaseContent],
+        metadata: BaseMetadata,
+        content: BaseContent,
         line_number: int,
     ) -> ExtractedBlock[BaseMetadata, BaseContent]:
-        """Create ExtractedBlock from parse result.
+        """Create ExtractedBlock from already-validated metadata and content.
 
         Args:
             candidate: Block candidate
-            parse_result: Successful parse result
+            metadata: Parsed metadata (caller guarantees non-None)
+            content: Parsed content (caller guarantees non-None)
             line_number: Current line number (end of block)
 
         Returns:
             ExtractedBlock with metadata, content, and extraction info
         """
         return ExtractedBlock(
-            metadata=parse_result.metadata,  # type: ignore[arg-type]  # Checked by caller
-            content=parse_result.content,  # type: ignore[arg-type]  # Checked by caller
+            metadata=metadata,
+            content=content,
             syntax_name=get_syntax_name(candidate.syntax),
             raw_text=candidate.raw_text,
             line_start=candidate.start_line,
@@ -524,8 +526,8 @@ class BlockStateMachine:
             )
             return self._create_error_event(candidate, line_number, "Missing metadata or content", error_code)
 
-        # Step 2: Create extracted block
-        block = self._create_extracted_block(candidate, parse_result, line_number)
+        # Step 2: Create extracted block (metadata/content narrowed non-None above)
+        block = self._create_extracted_block(candidate, parse_result.metadata, parse_result.content, line_number)
 
         # Step 3: Validate
         validation_error = self._validate_extracted_block(candidate, block, block_type, line_number)

--- a/src/hother/streamblocks/core/exceptions.py
+++ b/src/hother/streamblocks/core/exceptions.py
@@ -1,0 +1,87 @@
+"""Exception hierarchy raised by :mod:`hother.streamblocks`.
+
+A single base class :class:`StreamblocksError` with one level of subclasses;
+consumers can catch the base or a specific subclass without chasing deep
+inheritance trees.
+
+These exceptions are raised **synchronously** to signal programmer or
+configuration errors (an adapter was not configured, no adapter could be
+detected for a chunk type, an invalid syntax argument was passed). They abort
+the call that hit them.
+
+They are deliberately distinct from the per-block *runtime* error reporting in
+the stream: :class:`~hother.streamblocks.core.types.BlockErrorEvent` (carrying a
+:class:`~hother.streamblocks.core.types.BlockErrorCode`) is emitted **as data**
+into the event stream when an individual block fails to validate, exceeds the
+size limit, or is left unclosed. Stream-level, per-block problems stay events;
+misuse and impossible internal state become exceptions. Do not collapse the two.
+"""
+
+
+class StreamblocksError(Exception):
+    """Base class for all exceptions raised by ``hother.streamblocks``."""
+
+
+class AdapterNotConfiguredError(StreamblocksError):
+    """Raised when the input adapter is missing after first-chunk processing.
+
+    This signals an impossible internal state: by the time a chunk's text is
+    extracted, auto-detection should already have set an adapter.
+
+    Attributes:
+        context: The processing entry point where the missing adapter was
+            observed (e.g. ``"process_chunk"``, ``"process_stream"``,
+            ``"protocol_processor"``).
+    """
+
+    context: str
+
+    def __init__(self, *, context: str) -> None:
+        detail = "This indicates an internal state error."
+        message = f"Input adapter is not configured after first-chunk processing (context: {context}). {detail}"
+        super().__init__(message)
+        self.context = context
+
+
+class AdapterDetectionError(StreamblocksError):
+    """Raised when no input adapter can be auto-detected for a chunk type.
+
+    Attributes:
+        chunk_type: The fully-qualified type name of the unrecognised chunk
+            (e.g. ``"openai.types.ChatCompletionChunk"``).
+        registered_prefixes: The module prefixes currently registered for
+            auto-detection.
+    """
+
+    chunk_type: str
+    registered_prefixes: tuple[str, ...]
+
+    def __init__(self, *, chunk_type: str, registered_prefixes: tuple[str, ...]) -> None:
+        prefixes = list(registered_prefixes)
+        hint = "Consider importing the appropriate extension or registering a custom adapter."
+        message = f"No input adapter found for {chunk_type}. Registered module prefixes: {prefixes}. {hint}"
+        super().__init__(message)
+        self.chunk_type = chunk_type
+        self.registered_prefixes = registered_prefixes
+
+
+class SyntaxConfigError(StreamblocksError):
+    """Raised when a syntax argument is neither a ``Syntax`` enum nor a ``BaseSyntax``.
+
+    Attributes:
+        received_type: The name of the type that was passed instead.
+    """
+
+    received_type: str
+
+    def __init__(self, *, received_type: str) -> None:
+        super().__init__(f"Expected a Syntax enum member or BaseSyntax instance, got {received_type}.")
+        self.received_type = received_type
+
+
+__all__ = [
+    "AdapterDetectionError",
+    "AdapterNotConfiguredError",
+    "StreamblocksError",
+    "SyntaxConfigError",
+]

--- a/src/hother/streamblocks/core/parsing.py
+++ b/src/hother/streamblocks/core/parsing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from enum import StrEnum, auto
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import yaml
 from pydantic import ValidationError
@@ -67,7 +67,9 @@ def parse_as_yaml[T: BaseContent](
                     raise
                 return cls_inner(raw_content=raw_text)
 
-        cls.parse = classmethod(parse)  # type: ignore[assignment]
+        # Dynamically override the classmethod; the descriptor swap cannot be
+        # expressed in the type system, so cast rather than suppress.
+        cls.parse = cast("Any", classmethod(parse))
         return cls
 
     return decorator
@@ -118,7 +120,9 @@ def parse_as_json[T: BaseContent](
                     raise
                 return cls_inner(raw_content=raw_text)
 
-        cls.parse = classmethod(parse)  # type: ignore[assignment]
+        # Dynamically override the classmethod; the descriptor swap cannot be
+        # expressed in the type system, so cast rather than suppress.
+        cls.parse = cast("Any", classmethod(parse))
         return cls
 
     return decorator

--- a/src/hother/streamblocks/core/processor.py
+++ b/src/hother/streamblocks/core/processor.py
@@ -14,6 +14,7 @@ from hother.streamblocks.adapters.protocols import HasNativeModulePrefix
 from hother.streamblocks.core._logger import StdlibLoggerAdapter
 from hother.streamblocks.core.block_state_machine import BlockStateMachine
 from hother.streamblocks.core.constants import LIMITS
+from hother.streamblocks.core.exceptions import AdapterNotConfiguredError
 from hother.streamblocks.core.line_accumulator import LineAccumulator
 from hother.streamblocks.core.types import (
     BlockContentDeltaEvent,
@@ -206,8 +207,7 @@ class StreamBlockProcessor:
 
         # Extract text from chunk
         if self._adapter is None:
-            msg = "Adapter should be set after first chunk processing"
-            raise RuntimeError(msg)
+            raise AdapterNotConfiguredError(context="process_chunk")
         text = self._adapter.extract_text(chunk)  # type: ignore[arg-type]
 
         if not text:
@@ -386,8 +386,7 @@ class StreamBlockProcessor:
 
             # Extract text from chunk
             if self._adapter is None:
-                msg = "Adapter should be set after first chunk processing"
-                raise RuntimeError(msg)
+                raise AdapterNotConfiguredError(context="process_stream")
             text = self._adapter.extract_text(chunk)  # type: ignore[arg-type]
 
             if not text:

--- a/src/hother/streamblocks/core/processor.py
+++ b/src/hother/streamblocks/core/processor.py
@@ -208,9 +208,6 @@ class StreamBlockProcessor:
         # Extract text from chunk
         if self._adapter is None:
             raise AdapterNotConfiguredError(context="process_chunk")
-        # Earlier isinstance checks narrow self._adapter to a union whose
-        # IdentityInputAdapter arm types extract_text as str-only; cast back to the
-        # declared protocol so an arbitrary chunk type is accepted.
         text = cast("InputProtocolAdapter[Any]", self._adapter).extract_text(chunk)
 
         if not text:
@@ -390,8 +387,6 @@ class StreamBlockProcessor:
             # Extract text from chunk
             if self._adapter is None:
                 raise AdapterNotConfiguredError(context="process_stream")
-            # See process_chunk: cast back to the declared protocol type so the
-            # narrowed IdentityInputAdapter arm does not constrain extract_text to str.
             text = cast("InputProtocolAdapter[Any]", self._adapter).extract_text(chunk)
 
             if not text:

--- a/src/hother/streamblocks/core/processor.py
+++ b/src/hother/streamblocks/core/processor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from uuid import uuid4
 
 from hother.streamblocks.adapters.detection import InputAdapterRegistry
@@ -208,7 +208,10 @@ class StreamBlockProcessor:
         # Extract text from chunk
         if self._adapter is None:
             raise AdapterNotConfiguredError(context="process_chunk")
-        text = self._adapter.extract_text(chunk)  # type: ignore[arg-type]
+        # Earlier isinstance checks narrow self._adapter to a union whose
+        # IdentityInputAdapter arm types extract_text as str-only; cast back to the
+        # declared protocol so an arbitrary chunk type is accepted.
+        text = cast("InputProtocolAdapter[Any]", self._adapter).extract_text(chunk)
 
         if not text:
             return events
@@ -387,7 +390,9 @@ class StreamBlockProcessor:
             # Extract text from chunk
             if self._adapter is None:
                 raise AdapterNotConfiguredError(context="process_stream")
-            text = self._adapter.extract_text(chunk)  # type: ignore[arg-type]
+            # See process_chunk: cast back to the declared protocol type so the
+            # narrowed IdentityInputAdapter arm does not constrain extract_text to str.
+            text = cast("InputProtocolAdapter[Any]", self._adapter).extract_text(chunk)
 
             if not text:
                 continue

--- a/src/hother/streamblocks/core/protocol_processor.py
+++ b/src/hother/streamblocks/core/protocol_processor.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, TypeVar
 from hother.streamblocks.adapters.categories import EventCategory
 from hother.streamblocks.adapters.detection import detect_input_adapter
 from hother.streamblocks.adapters.output import StreamBlocksOutputAdapter
+from hother.streamblocks.core.exceptions import AdapterNotConfiguredError
 from hother.streamblocks.core.processor import ProcessorConfig, StreamBlockProcessor
 
 if TYPE_CHECKING:
@@ -183,8 +184,7 @@ class ProtocolStreamProcessor[TInput, TOutput]:
         """Process TEXT_CONTENT event and yield output events."""
         # _input_adapter is guaranteed to be set by _process_input_event
         if self._input_adapter is None:  # pragma: no cover
-            msg = "Input adapter not initialized - this should not happen"
-            raise RuntimeError(msg)
+            raise AdapterNotConfiguredError(context="protocol_processor")
         text = self._input_adapter.extract_text(input_event)
         if text:
             for sb_event in self._core_processor.process_chunk(text):

--- a/src/hother/streamblocks/core/protocol_processor.py
+++ b/src/hother/streamblocks/core/protocol_processor.py
@@ -310,8 +310,6 @@ class ProtocolStreamProcessor[TInput, TOutput]:
             Individual events
         """
         if isinstance(output, list):
-            # TOutput is unbounded so pyright widens list narrowing to list[Unknown];
-            # the declared parameter guarantees the element type.
             for item in cast("list[TOutput]", output):
                 yield item
         else:

--- a/src/hother/streamblocks/core/protocol_processor.py
+++ b/src/hother/streamblocks/core/protocol_processor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, TypeVar, cast
 
 from hother.streamblocks.adapters.categories import EventCategory
 from hother.streamblocks.adapters.detection import detect_input_adapter
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     )
     from hother.streamblocks.core._logger import Logger
     from hother.streamblocks.core.registry import Registry
+    from hother.streamblocks.core.types import Event
 
 TInput = TypeVar("TInput")
 TOutput = TypeVar("TOutput")
@@ -79,8 +80,12 @@ class ProtocolStreamProcessor[TInput, TOutput]:
         """
         self.registry = registry
         self._input_adapter = input_adapter
-        self._output_adapter: OutputProtocolAdapter[TOutput] = (
-            output_adapter if output_adapter is not None else StreamBlocksOutputAdapter()  # type: ignore[assignment]
+        # StreamBlocksOutputAdapter emits native BaseEvent output and cannot be
+        # statically proven to satisfy OutputProtocolAdapter[TOutput] for an arbitrary
+        # TOutput, so cast the default rather than suppress.
+        self._output_adapter: OutputProtocolAdapter[TOutput] = cast(
+            "OutputProtocolAdapter[TOutput]",
+            output_adapter if output_adapter is not None else StreamBlocksOutputAdapter(),
         )
         self._auto_detected = False
 
@@ -193,10 +198,14 @@ class ProtocolStreamProcessor[TInput, TOutput]:
 
     async def _transform_sb_event(
         self,
-        sb_event: str | object,
+        sb_event: Event | str,
     ) -> AsyncIterator[TOutput]:
         """Transform StreamBlocks event to output protocol events."""
-        output = self._output_adapter.to_protocol_event(sb_event)  # type: ignore[arg-type]
+        if isinstance(sb_event, str):  # pragma: no cover - emit_original_events is False here
+            # Original passthrough chunks are disabled for protocol processing,
+            # so only StreamBlocks events reach this transform.
+            return
+        output = self._output_adapter.to_protocol_event(sb_event)
         if output is not None:
             async for event in self._ensure_async_iterable(output):
                 yield event
@@ -238,6 +247,8 @@ class ProtocolStreamProcessor[TInput, TOutput]:
             if text:
                 # Process text chunk and get StreamBlocks events
                 for sb_event in self._core_processor.process_chunk(text):
+                    if isinstance(sb_event, str):  # pragma: no cover - emit_original_events is False here
+                        continue
                     output = self._output_adapter.to_protocol_event(sb_event)
                     if output is not None:
                         events.extend(self._ensure_list(output))
@@ -299,7 +310,9 @@ class ProtocolStreamProcessor[TInput, TOutput]:
             Individual events
         """
         if isinstance(output, list):
-            for item in output:
+            # TOutput is unbounded so pyright widens list narrowing to list[Unknown];
+            # the declared parameter guarantees the element type.
+            for item in cast("list[TOutput]", output):
                 yield item
         else:
             yield output
@@ -314,5 +327,6 @@ class ProtocolStreamProcessor[TInput, TOutput]:
             List of events
         """
         if isinstance(output, list):
-            return output
+            # See _ensure_async_iterable: narrow the unbounded-TypeVar list element type.
+            return cast("list[TOutput]", output)
         return [output]

--- a/src/hother/streamblocks/syntaxes/factory.py
+++ b/src/hother/streamblocks/syntaxes/factory.py
@@ -56,9 +56,6 @@ def get_syntax_instance(
             case Syntax.MARKDOWN_FRONTMATTER:
                 return MarkdownFrontmatterSyntax()
 
-    # A custom instance must inherit from BaseSyntax. Validate against ``object``
-    # rather than the declared type: callers may be untyped and pass an
-    # unsupported value (or a future, unhandled Syntax member), which must raise.
     unchecked = cast("object", syntax)
     if isinstance(unchecked, BaseSyntax):
         return unchecked

--- a/src/hother/streamblocks/syntaxes/factory.py
+++ b/src/hother/streamblocks/syntaxes/factory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum, auto
+from typing import cast
 
 from hother.streamblocks.core.exceptions import SyntaxConfigError
 from hother.streamblocks.syntaxes.base import BaseSyntax
@@ -54,12 +55,11 @@ def get_syntax_instance(
                 return DelimiterPreambleSyntax()
             case Syntax.MARKDOWN_FRONTMATTER:
                 return MarkdownFrontmatterSyntax()
-            case _:  # pragma: no cover - guard for future enum additions
-                error_msg = f"Unhandled Syntax enum value: {syntax}"
-                raise NotImplementedError(error_msg)
 
-    # It's a custom syntax instance - must inherit from BaseSyntax
-    if isinstance(syntax, BaseSyntax):
-        return syntax
-
-    raise SyntaxConfigError(received_type=type(syntax).__name__)
+    # A custom instance must inherit from BaseSyntax. Validate against ``object``
+    # rather than the declared type: callers may be untyped and pass an
+    # unsupported value (or a future, unhandled Syntax member), which must raise.
+    unchecked = cast("object", syntax)
+    if isinstance(unchecked, BaseSyntax):
+        return unchecked
+    raise SyntaxConfigError(received_type=type(unchecked).__name__)

--- a/src/hother/streamblocks/syntaxes/factory.py
+++ b/src/hother/streamblocks/syntaxes/factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum, auto
 
+from hother.streamblocks.core.exceptions import SyntaxConfigError
 from hother.streamblocks.syntaxes.base import BaseSyntax
 from hother.streamblocks.syntaxes.delimiter import (
     DelimiterFrontmatterSyntax,
@@ -35,7 +36,7 @@ def get_syntax_instance(
         A syntax instance inheriting from BaseSyntax
 
     Raises:
-        TypeError: If syntax is neither a Syntax enum nor a BaseSyntax instance
+        SyntaxConfigError: If syntax is neither a Syntax enum nor a BaseSyntax instance
 
     Example:
         >>> # Using built-in syntax
@@ -61,5 +62,4 @@ def get_syntax_instance(
     if isinstance(syntax, BaseSyntax):
         return syntax
 
-    error_msg = f"Expected Syntax enum or BaseSyntax instance, got {type(syntax).__name__}"
-    raise TypeError(error_msg)
+    raise SyntaxConfigError(received_type=type(syntax).__name__)

--- a/tests/adapters/test_adapter_detection.py
+++ b/tests/adapters/test_adapter_detection.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hother.streamblocks.extensions.anthropic
 import hother.streamblocks.extensions.gemini
 import hother.streamblocks.extensions.openai  # noqa: F401
+from hother.streamblocks import AdapterDetectionError
 from hother.streamblocks.adapters import (
     EventCategory,
     InputAdapterRegistry,
@@ -107,13 +108,13 @@ class TestInputAdapterRegistry:
         assert adapter is None
 
     def test_detect_input_adapter_raises_for_unknown(self):
-        """detect_input_adapter should raise ValueError for unknown formats."""
+        """detect_input_adapter should raise AdapterDetectionError for unknown formats."""
         import pytest
 
         class WeirdChunk:
             data = "no standard attributes"
 
-        with pytest.raises(ValueError, match="No input adapter found"):
+        with pytest.raises(AdapterDetectionError, match="No input adapter found"):
             detect_input_adapter(WeirdChunk())
 
     def test_custom_adapter_registration_by_module(self):

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -1,0 +1,71 @@
+"""Tests for the Streamblocks exception hierarchy."""
+
+import pytest
+
+from hother.streamblocks import (
+    AdapterDetectionError,
+    AdapterNotConfiguredError,
+    StreamblocksError,
+    SyntaxConfigError,
+)
+
+
+class TestStreamblocksError:
+    """Tests for the base exception class."""
+
+    def test_is_exception_subclass(self) -> None:
+        """The base class is a plain Exception subclass."""
+        assert issubclass(StreamblocksError, Exception)
+
+    @pytest.mark.parametrize(
+        "subclass",
+        [AdapterNotConfiguredError, AdapterDetectionError, SyntaxConfigError],
+    )
+    def test_subclasses_share_base(self, subclass: type[StreamblocksError]) -> None:
+        """Every concrete exception derives from StreamblocksError."""
+        assert issubclass(subclass, StreamblocksError)
+
+
+class TestAdapterNotConfiguredError:
+    """Tests for AdapterNotConfiguredError."""
+
+    def test_message_and_attribute(self) -> None:
+        """The context is stored and rendered in the message."""
+        error = AdapterNotConfiguredError(context="process_chunk")
+
+        assert error.context == "process_chunk"
+        assert "process_chunk" in str(error)
+        assert "internal state error" in str(error)
+
+    def test_catchable_as_base(self) -> None:
+        """It can be caught via the base class."""
+        with pytest.raises(StreamblocksError):
+            raise AdapterNotConfiguredError(context="process_stream")
+
+
+class TestAdapterDetectionError:
+    """Tests for AdapterDetectionError."""
+
+    def test_message_and_attributes(self) -> None:
+        """Chunk type and registered prefixes are stored and rendered."""
+        error = AdapterDetectionError(
+            chunk_type="openai.types.ChatCompletionChunk",
+            registered_prefixes=("anthropic", "google"),
+        )
+
+        assert error.chunk_type == "openai.types.ChatCompletionChunk"
+        assert error.registered_prefixes == ("anthropic", "google")
+        assert "openai.types.ChatCompletionChunk" in str(error)
+        assert "anthropic" in str(error)
+
+
+class TestSyntaxConfigError:
+    """Tests for SyntaxConfigError."""
+
+    def test_message_and_attribute(self) -> None:
+        """The received type name is stored and rendered."""
+        error = SyntaxConfigError(received_type="str")
+
+        assert error.received_type == "str"
+        assert "str" in str(error)
+        assert "Syntax enum" in str(error)

--- a/tests/core/test_processor.py
+++ b/tests/core/test_processor.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hother.streamblocks import Registry
+from hother.streamblocks import AdapterNotConfiguredError, Registry
 from hother.streamblocks.adapters.input import IdentityInputAdapter
 from hother.streamblocks.adapters.protocols import InputProtocolAdapter
 from hother.streamblocks.core.processor import (
@@ -195,10 +195,7 @@ class TestStreamBlockProcessorProcessChunk:
         assert len(text_deltas) == 0
 
     def test_process_chunk_raises_if_adapter_not_set(self, registry: Registry) -> None:
-        """Test RuntimeError if adapter is None after first chunk.
-
-        This covers lines 174-175.
-        """
+        """Test AdapterNotConfiguredError if adapter is None after first chunk."""
         config = ProcessorConfig(auto_detect_adapter=False)
         processor = StreamBlockProcessor(registry, config=config)
 
@@ -207,7 +204,7 @@ class TestStreamBlockProcessorProcessChunk:
         processor._first_chunk_processed = True
         processor._adapter = None
 
-        with pytest.raises(RuntimeError, match="Adapter should be set"):
+        with pytest.raises(AdapterNotConfiguredError, match="process_chunk"):
             processor.process_chunk("text")
 
 
@@ -418,10 +415,7 @@ class TestStreamBlockProcessorProcessStream:
 
     @pytest.mark.asyncio
     async def test_process_stream_raises_if_adapter_not_set(self, registry: Registry) -> None:
-        """Test RuntimeError if adapter is None after first chunk.
-
-        This covers lines 350-351.
-        """
+        """Test AdapterNotConfiguredError if adapter is None after first chunk."""
         config = ProcessorConfig(auto_detect_adapter=False)
         processor = StreamBlockProcessor(registry, config=config)
 
@@ -432,7 +426,7 @@ class TestStreamBlockProcessorProcessStream:
         async def mock_stream():
             yield "text"
 
-        with pytest.raises(RuntimeError, match="Adapter should be set"):
+        with pytest.raises(AdapterNotConfiguredError, match="process_stream"):
             async for _event in processor.process_stream(mock_stream()):
                 pass
 

--- a/tests/syntaxes/test_models.py
+++ b/tests/syntaxes/test_models.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from hother.streamblocks import SyntaxConfigError
 from hother.streamblocks.core.types import BaseContent, BaseMetadata, DetectionResult, ParseResult
 from hother.streamblocks.syntaxes.delimiter import (
     DelimiterFrontmatterSyntax,
@@ -141,7 +142,7 @@ class TestGetSyntaxInstanceWithCustomSyntax:
             ) -> ParseResult[BaseMetadata, BaseContent]:
                 return ParseResult(success=False, error="Not implemented")
 
-        with pytest.raises(TypeError, match="Expected Syntax enum or BaseSyntax instance"):
+        with pytest.raises(SyntaxConfigError, match="Expected a Syntax enum member or BaseSyntax instance"):
             get_syntax_instance(DuckTypedSyntax())  # type: ignore[arg-type]
 
 
@@ -149,27 +150,27 @@ class TestGetSyntaxInstanceErrors:
     """Tests for get_syntax_instance() error cases."""
 
     def test_invalid_string_raises_type_error(self) -> None:
-        """Test that a plain string raises TypeError."""
-        with pytest.raises(TypeError, match="Expected Syntax enum or BaseSyntax instance"):
+        """Test that a plain string raises SyntaxConfigError."""
+        with pytest.raises(SyntaxConfigError, match="Expected a Syntax enum member or BaseSyntax instance"):
             get_syntax_instance("invalid")  # type: ignore[arg-type]
 
     def test_invalid_number_raises_type_error(self) -> None:
-        """Test that a number raises TypeError."""
-        with pytest.raises(TypeError, match="Expected Syntax enum or BaseSyntax instance"):
+        """Test that a number raises SyntaxConfigError."""
+        with pytest.raises(SyntaxConfigError, match="Expected a Syntax enum member or BaseSyntax instance"):
             get_syntax_instance(123)  # type: ignore[arg-type]
 
     def test_invalid_none_raises_type_error(self) -> None:
-        """Test that None raises TypeError."""
-        with pytest.raises(TypeError, match="Expected Syntax enum or BaseSyntax instance"):
+        """Test that None raises SyntaxConfigError."""
+        with pytest.raises(SyntaxConfigError, match="Expected a Syntax enum member or BaseSyntax instance"):
             get_syntax_instance(None)  # type: ignore[arg-type]
 
     def test_invalid_dict_raises_type_error(self) -> None:
-        """Test that a dict raises TypeError."""
-        with pytest.raises(TypeError, match="Expected Syntax enum or BaseSyntax instance"):
+        """Test that a dict raises SyntaxConfigError."""
+        with pytest.raises(SyntaxConfigError, match="Expected a Syntax enum member or BaseSyntax instance"):
             get_syntax_instance({"detect_line": True})  # type: ignore[arg-type]
 
     def test_incomplete_object_raises_type_error(self) -> None:
-        """Test that an object without required methods raises TypeError."""
+        """Test that an object without required methods raises SyntaxConfigError."""
 
         class IncompleteSyntax:
             def detect_line(self, line: str) -> DetectionResult:
@@ -177,12 +178,12 @@ class TestGetSyntaxInstanceErrors:
 
             # Missing parse_block method
 
-        with pytest.raises(TypeError, match="Expected Syntax enum or BaseSyntax instance"):
+        with pytest.raises(SyntaxConfigError, match="Expected a Syntax enum member or BaseSyntax instance"):
             get_syntax_instance(IncompleteSyntax())  # type: ignore[arg-type]
 
     def test_error_message_includes_type_info(self) -> None:
         """Test that error message includes the type of invalid input."""
-        with pytest.raises(TypeError) as exc_info:
+        with pytest.raises(SyntaxConfigError) as exc_info:
             get_syntax_instance([1, 2, 3])  # type: ignore[arg-type]
 
         assert "list" in str(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -407,6 +407,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1899,6 +1908,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2224,7 +2258,7 @@ wheels = [
 
 [[package]]
 name = "streamblocks"
-version = "0.0.1"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -2273,6 +2307,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "pytest-xdist" },
     { name = "rich" },
     { name = "ruff" },
     { name = "typer" },
@@ -2321,6 +2357,8 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.21" },
     { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "pytest-randomly", specifier = ">=3.16" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", specifier = ">=0.8" },
     { name = "typer", specifier = ">=0.12.0" },


### PR DESCRIPTION
## Summary

Aligns Streamblocks with the conventions it already states it follows, and adopts the
test-determinism + canonical-docs patterns from the sibling `intrinsic-green-learning`
repo. No behavioural changes to the public API beyond the new exception types.

## WS1 — Core type-safety & errors

- **New exception hierarchy** (`core/exceptions.py`): `StreamblocksError` base with flat,
  typed subclasses (`AdapterNotConfiguredError`, `AdapterDetectionError`,
  `SyntaxConfigError`). The module docstring states the boundary: **exceptions = synchronous
  misuse/config errors**, while `BlockErrorEvent`/`BlockErrorCode` remain **per-block runtime
  errors emitted into the stream**. Replaces 5 raw `RuntimeError`/`ValueError`/`TypeError`
  raises. Exported from the package root.
- **Removed all 9 `# type: ignore` / `# noqa`** in `src/` — the repo's own `CLAUDE.local.md`
  forbids them. Fixed by tightening types / restructuring, or a narrow justified `typing.cast`
  (not a suppression) where behaviour is genuinely dynamic.
- **Un-ignored 3 pyright-skipped files** (`protocol_processor.py`, `detection.py`,
  `factory.py`) and fixed the latent strict errors that surfaced. The pyright `ignore` list
  now holds only out-of-scope `agui/` (missing stubs) and `blocks/*` (Literal narrowing).

## WS2 — Dev infra (from IGL)

- `pytest-randomly` + `pytest-xdist -n auto` + `xfail_strict` — suite verified
  order-independent across reshuffles.
- Canonical **`AGENTS.md`** consolidating the enforced conventions (linked from
  `docs/contributing.md`).
- Root-anchored `.gitignore` entries for BFCL benchmark scratch files.

## Verification

- `grep -rn "type: ignore\|noqa" src/hother/streamblocks` (excl. examples) → empty
- `basedpyright src` → 0 errors, strict
- `pytest` → 703 passed, 8 skipped, **100% branch coverage** (shuffled + parallel)
- `run_examples.py` → 37/37 pass
