### PR TITLE
feat: registry→prompt generation in core

### DIFF
--- a/docs/concepts/blocks-and-registry.md
+++ b/docs/concepts/blocks-and-registry.md
@@ -106,6 +106,10 @@ You do not have to register anything. A block whose `block_type` has no register
 
 This minimal API is handy for prototyping before you commit to typed models. See the full example in [Basics examples](../examples/basics.md).
 
+## The block round-trip
+
+Block definitions are *self-describing*: the docstring, metadata fields, content format, and `__examples__` carry everything needed to explain the block to a model. `Registry.to_prompt()` turns the registry into instructions telling the model which blocks to emit and in what format; the model streams that text back; and the **same** registry parses it into typed [`ExtractedBlock`](#block-vs-extractedblock) instances. Because both directions are driven by one set of definitions, the prompt and the parser never drift apart. See [Generating Prompts](../guides/generate-prompts.md) for the how-to.
+
 ## Next steps
 
 - [Syntaxes](syntaxes.md): the wire formats a registry can detect.

--- a/docs/examples/basics.md
+++ b/docs/examples/basics.md
@@ -37,3 +37,9 @@ Validates block metadata early, before content streams in, and shows the availab
 Chains multiple validators (metadata, content, and general block validators) on a single block type, showing how validation responsibilities compose.
 
 #! src/hother/streamblocks_examples/01_basics/06_validator_composition.py
+
+## Prompt Generation
+
+Builds an LLM system prompt from a registry with `Registry.to_prompt()` and `generate_block_prompt()` — the syntax format, block docstrings, content-format hints, and serialized examples — entirely offline. See the [Generating Prompts](../guides/generate-prompts.md) guide.
+
+#! src/hother/streamblocks_examples/01_basics/07_prompt_generation.py

--- a/docs/guides/generate-prompts.md
+++ b/docs/guides/generate-prompts.md
@@ -1,0 +1,57 @@
+# Generating Prompts
+
+For a model to emit blocks your registry can parse, it needs to know the block format. Rather than hand-writing that prompt, `Registry.to_prompt()` builds it from your block definitions — the docstring, metadata fields, content format, and examples. The *same* registry then parses the model's output, so the instructions and the parser never drift apart. See [Blocks & Registry](../concepts/blocks-and-registry.md#the-block-round-trip) for the round-trip idea.
+
+## Make your blocks self-describing
+
+Prompt quality comes straight from your block definitions. Three things feed the prompt:
+
+- the **block docstring**: the first paragraph is the description; a paragraph starting with `Usage:` becomes the usage guidance (this is the only convention — implicit phrasing is not detected).
+- the **content format**: `@parse_as_json` / `@parse_as_yaml` mark the body format, rendered as a JSON/YAML structure hint built from the content model's fields and their `Field(description=...)`.
+- **examples**: `__examples__` entries are serialized in the registry's syntax and shown verbatim.
+
+```python
+--8<-- "src/hother/streamblocks_examples/01_basics/07_prompt_generation.py:imports"
+```
+
+```python
+--8<-- "src/hother/streamblocks_examples/01_basics/07_prompt_generation.py:blocks"
+```
+
+## Generate a registry prompt
+
+`Registry.to_prompt()` documents every registered block in the registry's syntax:
+
+```python
+--8<-- "src/hother/streamblocks_examples/01_basics/07_prompt_generation.py:registry_prompt"
+```
+
+Pass `include_examples=False` to omit the examples section. Because the prompt is built from the registry's own syntax, switching syntaxes (for example `MarkdownFrontmatterSyntax`) changes the format shown to the model automatically.
+
+## Document a single block
+
+For one block type, call `generate_block_prompt(block_class, syntax, ...)`:
+
+```python
+--8<-- "src/hother/streamblocks_examples/01_basics/07_prompt_generation.py:single"
+```
+
+## Customize the template
+
+Prompts render through Jinja2 templates. Register a custom template and select it with `template_version`; the template context exposes `syntax_name`, `syntax_format`, and `blocks`:
+
+```python
+--8<-- "src/hother/streamblocks_examples/01_basics/07_prompt_generation.py:templates"
+```
+
+This is handy for A/B testing prompt phrasings without touching block definitions.
+
+## Serialize blocks back to text
+
+`Registry.serialize_block()` (and each syntax's `serialize_block()`) renders a `Block` instance into its wire format — the same mechanism used to render `__examples__`. It is the inverse of parsing, useful for few-shot examples or round-trip tests. `BaseSyntax.describe_format()` returns the human-readable format description embedded in the prompt.
+
+## Next steps
+
+- [Pydantic AI](pydantic-ai.md): feed the generated prompt to an agent, then extract blocks from its stream.
+- [Defining Custom Blocks](define-custom-blocks.md): the block models the prompt is built from.
+- [Prompts reference](../reference/prompts.md): the full API.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -5,6 +5,7 @@ Task-oriented guides for common StreamBlocks workflows. Each guide is backed by 
 ## Building blocks
 
 - [Defining Custom Blocks](define-custom-blocks.md): typed metadata/content models, custom parsing, JSON/YAML content.
+- [Generating Prompts](generate-prompts.md): build an LLM system prompt from your registry.
 - [Validation](validation.md): registry validators, failure modes, early validation.
 - [Error Handling](error-handling.md): error codes, unclosed blocks, size limits.
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -19,11 +19,19 @@ from hother.streamblocks import Registry, StreamBlockProcessor, BlockEndEvent
 
 [Registry & Models](registry-and-models.md)
 
-- `Registry`: maps block types to block classes; owns the syntax
-- `Block[TMetadata, TContent]`: user-facing generic block base
+- `Registry`: maps block types to block classes; owns the syntax. `to_prompt()`, `register_template()`, `serialize_block()`, and `registered_blocks` support prompt generation
+- `Block[TMetadata, TContent]`: user-facing generic block base; `__examples__` + `get_examples()` feed prompts
 - `ExtractedBlock`: runtime block with extraction metadata
 - `BlockCandidate`: in-flight block accumulation
 - `BaseMetadata`, `BaseContent`: base Pydantic models for block typing
+
+## Prompts
+
+[Prompts](prompts.md)
+
+- `generate_block_prompt`: build an instruction prompt for a single block type
+- `TemplateManager`: Jinja2 template management for prompt A/B versioning
+- See also `Registry.to_prompt()` and the [Generating Prompts](../guides/generate-prompts.md) guide
 
 ## Events
 

--- a/docs/reference/prompts.md
+++ b/docs/reference/prompts.md
@@ -1,0 +1,5 @@
+# Prompts
+
+Generate LLM instruction prompts from a block [`Registry`](registry-and-models.md) (or a single block type) so models emit blocks the same registry can parse. See the [Generating Prompts](../guides/generate-prompts.md) guide for usage. `Registry.to_prompt()`, `Registry.register_template()`, and `Registry.serialize_block()` are documented on the [Registry & Models](registry-and-models.md) page.
+
+::: hother.streamblocks.prompts

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
   - Guides:
     - guides/index.md
     - Defining Custom Blocks: guides/define-custom-blocks.md
+    - Generating Prompts: guides/generate-prompts.md
     - Validation: guides/validation.md
     - Error Handling: guides/error-handling.md
     - OpenAI, Anthropic & Gemini: guides/providers.md
@@ -40,6 +41,7 @@ nav:
     - reference/index.md
     - Processors: reference/processors.md
     - Registry & Models: reference/registry-and-models.md
+    - Prompts: reference/prompts.md
     - Events: reference/events.md
     - Syntaxes: reference/syntaxes.md
     - Adapters: reference/adapters.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 ]
 requires-python = ">=3.13"
 dependencies = [
+    "jinja2>=3.1.0",
     "pydantic-ai>=1.0.9",
     "pydantic>=2.12.4",
     "pyyaml>=6.0",
@@ -312,9 +313,15 @@ line-ending = "auto"
 ]
 "src/hother/streamblocks/core/models.py" = [
     "UP046",   # Type annotation can be modernized
+    "PLC0415", # Import not at top-level (needed to avoid circular imports with syntaxes)
 ]
 "src/hother/streamblocks/syntaxes/markdown.py" = [
     "TRY300",   # Conflicts with RET505 - allow simple return after if
+]
+"src/hother/streamblocks/prompts/manager.py" = [
+    # Prompts are plain text / markdown for LLMs, not HTML. Autoescaping would
+    # corrupt example content (e.g. quotes in JSON), so it is intentionally off.
+    "S701",
 ]
 "src/hother/streamblocks/adapters/**/*" = [
     "PLC0105",  # TypeVar contravariance naming - TChunk is clear enough

--- a/src/hother/streamblocks/__init__.py
+++ b/src/hother/streamblocks/__init__.py
@@ -52,6 +52,7 @@ from hother.streamblocks.core.types import (
     TextContentEvent,
     TextDeltaEvent,
 )
+from hother.streamblocks.prompts import TemplateManager, generate_block_prompt
 from hother.streamblocks.syntaxes import (
     DelimiterFrontmatterSyntax,
     DelimiterPreambleSyntax,
@@ -115,9 +116,11 @@ __all__ = [
     "StreamFinishedEvent",
     "StreamStartedEvent",
     "StreamState",
+    "TemplateManager",
     "TextContentEvent",
     "TextDeltaEvent",
     "ValidationResult",
+    "generate_block_prompt",
     "parse_as_json",
     "parse_as_yaml",
 ]

--- a/src/hother/streamblocks/core/models.py
+++ b/src/hother/streamblocks/core/models.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import hashlib
-from typing import TYPE_CHECKING, Any
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 
+import yaml
 from pydantic import BaseModel, Field
 
 from hother.streamblocks.core.constants import LIMITS
@@ -12,6 +15,11 @@ from hother.streamblocks.core.types import BaseContent, BaseMetadata, BlockState
 
 if TYPE_CHECKING:
     from hother.streamblocks.syntaxes.base import BaseSyntax
+
+# YAML frontmatter delimiters for markdown examples files
+_FRONTMATTER_FENCE = "---"
+# A valid frontmatter document splits into [pre, frontmatter, body] on the fence
+_FRONTMATTER_PART_COUNT = 3
 
 
 def extract_block_types(block_class: type[Any]) -> tuple[type[BaseMetadata], type[BaseContent]]:
@@ -172,6 +180,161 @@ class Block[TMetadata: BaseMetadata, TContent: BaseContent](BaseModel):
 
     metadata: TMetadata = Field(..., description="Parsed block metadata")
     content: TContent = Field(..., description="Parsed block content")
+
+    # Declared examples for this block type. Either a list of
+    # {"metadata": {...}, "content": {...}} dicts, or a path (Path or str) to a
+    # markdown file with YAML frontmatter that names the syntax. Used by prompt
+    # generation.
+    __examples__: ClassVar[list[dict[str, Any]] | Path | str] = []
+
+    # Examples added at runtime via add_example(), keyed by concrete class so
+    # subclasses do not share storage.
+    _dynamic_examples: ClassVar[dict[type, list[Any]]] = {}
+    # Cache of file-loaded examples keyed by (class, resolved_path, mtime).
+    _examples_file_cache: ClassVar[dict[tuple[type, str, float], list[Any]]] = {}
+
+    @classmethod
+    def add_example(cls, example: Self | dict[str, Any]) -> None:
+        """Add a single example for this block type.
+
+        Args:
+            example: A block instance, or a dict with ``metadata`` and
+                ``content`` keys. Missing ``raw_content`` is auto-filled.
+        """
+        instance = cls._example_from_dict(example) if isinstance(example, dict) else example
+        cls._dynamic_examples.setdefault(cls, []).append(instance)
+
+    @classmethod
+    def add_examples(cls, examples: list[Self | dict[str, Any]]) -> None:
+        """Add multiple examples for this block type."""
+        for example in examples:
+            cls.add_example(example)
+
+    @classmethod
+    def clear_examples(cls) -> None:
+        """Clear examples added via add_example().
+
+        Does not affect examples declared in the ``__examples__`` attribute.
+        """
+        cls._dynamic_examples[cls] = []
+
+    @classmethod
+    def get_examples(cls) -> list[Self]:
+        """Return all examples (declared + dynamically added) as instances.
+
+        Declared examples come from ``__examples__`` (inline dicts or a markdown
+        file). Dynamically added examples come from :meth:`add_example`.
+        """
+        declared = cls.__examples__
+        if isinstance(declared, (str, Path)):
+            examples = cls._load_examples_from_file(declared)
+        else:
+            examples = [cls._example_from_dict(item) for item in declared]
+        examples.extend(cls._dynamic_examples.get(cls, []))
+        return examples
+
+    @classmethod
+    def _example_from_dict(cls, data: dict[str, Any]) -> Self:
+        """Validate an example dict into an instance, auto-filling raw_content."""
+        return cls.model_validate(cls._ensure_raw_content(data))
+
+    @classmethod
+    def _ensure_raw_content(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Fill a missing content ``raw_content`` by serializing content fields.
+
+        Honors an explicit ``raw_content`` when present. The serialization
+        format follows the block's declared content format
+        (``__content_format__`` set by ``@parse_as_json`` / ``@parse_as_yaml``),
+        defaulting to JSON. Block types with bespoke content formats should
+        provide ``raw_content`` explicitly in their examples.
+        """
+        content_value = data.get("content")
+        if not isinstance(content_value, dict) or "raw_content" in content_value:
+            return data
+        content = cast("dict[str, Any]", content_value)
+        fields = {key: value for key, value in content.items() if key != "raw_content"}
+        _, content_class = extract_block_types(cls)
+        if content_class.__content_format__ == "yaml":
+            raw_content = yaml.dump(fields, default_flow_style=False, sort_keys=False).strip()
+        else:
+            raw_content = json.dumps(fields, ensure_ascii=False)
+        return {**data, "content": {**content, "raw_content": raw_content}}
+
+    @classmethod
+    def _load_examples_from_file(cls, path: Path | str) -> list[Self]:
+        """Load and cache examples from a markdown file with YAML frontmatter."""
+        file_path = Path(path).resolve()
+        if not file_path.is_file():
+            msg = f"Examples file not found: {file_path}"
+            raise FileNotFoundError(msg)
+
+        mtime = file_path.stat().st_mtime
+        cache_key = (cls, str(file_path), mtime)
+        cached = cls._examples_file_cache.get(cache_key)
+        if cached is not None:
+            return list(cached)
+
+        content = file_path.read_text(encoding="utf-8")
+        syntax, blocks_content = cls._parse_examples_frontmatter(content, file_path)
+        examples = cls._extract_blocks_from_content(blocks_content, syntax)
+        cls._examples_file_cache[cache_key] = examples
+        return list(examples)
+
+    @classmethod
+    def _parse_examples_frontmatter(cls, content: str, file_path: Path) -> tuple[BaseSyntax, str]:
+        """Split a markdown examples file into (syntax instance, blocks text)."""
+        from hother.streamblocks.syntaxes.factory import get_syntax_instance
+        from hother.streamblocks.syntaxes.models import Syntax
+
+        if not content.lstrip().startswith(_FRONTMATTER_FENCE):
+            msg = f"Examples file must start with YAML frontmatter: {file_path}"
+            raise ValueError(msg)
+
+        parts = content.split(_FRONTMATTER_FENCE, 2)
+        if len(parts) < _FRONTMATTER_PART_COUNT:
+            msg = f"Invalid frontmatter in examples file: {file_path}"
+            raise ValueError(msg)
+
+        parsed = yaml.safe_load(parts[1].strip())
+        if not isinstance(parsed, dict):
+            msg = f"Frontmatter must be a YAML mapping: {file_path}"
+            raise TypeError(msg)
+
+        frontmatter = cast("dict[str, Any]", parsed)
+        syntax_name = frontmatter.get("syntax")
+        if not isinstance(syntax_name, str):
+            msg = f"Frontmatter must name a string 'syntax' field: {file_path}"
+            raise TypeError(msg)
+
+        try:
+            syntax = get_syntax_instance(Syntax[syntax_name])
+        except KeyError as error:
+            valid = ", ".join(member.name for member in Syntax)
+            msg = f"Unknown syntax '{syntax_name}' in {file_path}. Valid options: {valid}"
+            raise ValueError(msg) from error
+
+        return syntax, parts[2].strip()
+
+    @classmethod
+    def _extract_blocks_from_content(cls, content: str, syntax: BaseSyntax) -> list[Self]:
+        """Parse all blocks in a text body using the given syntax."""
+        examples: list[Self] = []
+        candidate: BlockCandidate | None = None
+        for line in content.split("\n"):
+            if candidate is None:
+                if syntax.detect_line(line, None).is_opening:
+                    candidate = BlockCandidate(syntax=syntax, start_line=0)
+                    candidate.add_line(line)
+                continue
+            candidate.add_line(line)
+            if syntax.detect_line(line, candidate).is_closing:
+                result = syntax.parse_block(candidate, block_class=cls)
+                if not result.success or result.metadata is None or result.content is None:
+                    msg = f"Failed to parse example block: {result.error or 'incomplete block'}"
+                    raise ValueError(msg)
+                examples.append(cls.model_validate({"metadata": result.metadata, "content": result.content}))
+                candidate = None
+        return examples
 
 
 class ExtractedBlock[TMetadata: BaseMetadata, TContent: BaseContent](Block[TMetadata, TContent]):

--- a/src/hother/streamblocks/core/parsing.py
+++ b/src/hother/streamblocks/core/parsing.py
@@ -70,6 +70,7 @@ def parse_as_yaml[T: BaseContent](
         # Dynamically override the classmethod; the descriptor swap cannot be
         # expressed in the type system, so cast rather than suppress.
         cls.parse = cast("Any", classmethod(parse))
+        cls.__content_format__ = "yaml"
         return cls
 
     return decorator
@@ -123,6 +124,7 @@ def parse_as_json[T: BaseContent](
         # Dynamically override the classmethod; the descriptor swap cannot be
         # expressed in the type system, so cast rather than suppress.
         cls.parse = cast("Any", classmethod(parse))
+        cls.__content_format__ = "json"
         return cls
 
     return decorator

--- a/src/hother/streamblocks/core/registry.py
+++ b/src/hother/streamblocks/core/registry.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from hother.streamblocks.core._logger import StdlibLoggerAdapter
+from hother.streamblocks.prompts.builder import build_block_context
+from hother.streamblocks.prompts.manager import TemplateManager
 from hother.streamblocks.syntaxes.factory import get_syntax_instance
 from hother.streamblocks.syntaxes.models import Syntax
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from hother.streamblocks.core._logger import Logger
     from hother.streamblocks.core.models import Block, ExtractedBlock
     from hother.streamblocks.syntaxes.base import BaseSyntax
@@ -105,6 +110,7 @@ class Registry:
         self._metadata_validators: dict[BlockType, list[MetadataValidatorFunc]] = {}
         self._content_validators: dict[BlockType, list[ContentValidatorFunc]] = {}
         self._metadata_failure_mode = metadata_failure_mode
+        self._template_manager: TemplateManager | None = None
         self.logger = logger or StdlibLoggerAdapter(logging.getLogger(__name__))
 
         # Bulk register blocks if provided
@@ -116,6 +122,56 @@ class Registry:
     def syntax(self) -> BaseSyntax:
         """Get the syntax instance."""
         return self._syntax
+
+    @property
+    def registered_blocks(self) -> Mapping[str, type[Block[Any, Any]]]:
+        """Read-only view of registered block types mapped to block classes."""
+        return MappingProxyType(self._block_classes)
+
+    def to_prompt(self, *, include_examples: bool = True, template_version: str = "default") -> str:
+        """Generate an LLM system prompt documenting all registered blocks.
+
+        The prompt describes this registry's syntax format and, for each
+        registered block type, its description, metadata fields, content
+        format, and (optionally) serialized examples.
+
+        Args:
+            include_examples: Whether to render each block's examples.
+            template_version: Template version for A/B testing.
+
+        Returns:
+            The rendered system prompt.
+        """
+        blocks = [
+            build_block_context(block_class, self._syntax, include_examples=include_examples)
+            for block_class in self._block_classes.values()
+        ]
+        context: dict[str, Any] = {
+            "syntax_name": type(self._syntax).__name__,
+            "syntax_format": self._syntax.describe_format(),
+            "blocks": blocks,
+        }
+        return self._get_template_manager().render(context, template_version, mode="registry")
+
+    def register_template(self, version: str, template: str | Path, mode: str = "both") -> None:
+        """Register a custom prompt template for this registry.
+
+        Args:
+            version: Version identifier used by ``to_prompt(template_version=...)``.
+            template: Template string, or a Path to a template file.
+            mode: "registry", "single", or "both".
+        """
+        self._get_template_manager().register_template(version, template, mode)
+
+    def serialize_block(self, block: Block[Any, Any]) -> str:
+        """Serialize a block instance using this registry's syntax."""
+        return self._syntax.serialize_block(block)
+
+    def _get_template_manager(self) -> TemplateManager:
+        """Lazily create the per-registry template manager."""
+        if self._template_manager is None:
+            self._template_manager = TemplateManager()
+        return self._template_manager
 
     def register(
         self,

--- a/src/hother/streamblocks/core/types.py
+++ b/src/hother/streamblocks/core/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from enum import StrEnum
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Self
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Self
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
@@ -78,6 +78,11 @@ class BaseContent(BaseModel):
     """
 
     raw_content: str = Field(..., description="Raw unparsed content from the block")
+
+    # Format marker set by the @parse_as_json / @parse_as_yaml decorators.
+    # Used by prompt generation to describe the expected content format without
+    # fragile source/bytecode introspection. None means "no declared format".
+    __content_format__: ClassVar[str | None] = None
 
     @classmethod
     def parse(cls, raw_text: str) -> Self:

--- a/src/hother/streamblocks/prompts/__init__.py
+++ b/src/hother/streamblocks/prompts/__init__.py
@@ -1,0 +1,9 @@
+"""Prompt generation from block registries and block classes."""
+
+from hother.streamblocks.prompts.builder import generate_block_prompt
+from hother.streamblocks.prompts.manager import TemplateManager
+
+__all__ = [
+    "TemplateManager",
+    "generate_block_prompt",
+]

--- a/src/hother/streamblocks/prompts/builder.py
+++ b/src/hother/streamblocks/prompts/builder.py
@@ -1,0 +1,134 @@
+"""Build LLM prompt context and text from block classes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from hother.streamblocks.core.models import extract_block_types
+from hother.streamblocks.prompts.inspector import inspect_content_format, parse_block_docstring
+from hother.streamblocks.prompts.manager import TemplateManager
+
+if TYPE_CHECKING:
+    from hother.streamblocks.core.models import Block
+    from hother.streamblocks.core.types import BaseContent, BaseMetadata
+    from hother.streamblocks.syntaxes.base import BaseSyntax
+
+_METADATA_FIELD = "metadata"
+_CONTENT_FIELD = "content"
+# Fields excluded from generated schemas because they are auto-populated.
+_ALWAYS_EXCLUDED: dict[str, set[str]] = {
+    _METADATA_FIELD: {"id", "block_type"},
+    _CONTENT_FIELD: {"raw_content"},
+}
+
+
+def generate_block_prompt(
+    block_class: type[Block[Any, Any]],
+    syntax: BaseSyntax,
+    *,
+    include_examples: bool = True,
+    template_version: str = "default",
+    description: str = "",
+) -> str:
+    """Generate an instruction prompt for a single block type.
+
+    Args:
+        block_class: The block class to document.
+        syntax: Syntax used to describe the format and serialize examples.
+        include_examples: Whether to render examples from ``get_examples()``.
+        template_version: Template version for A/B testing.
+        description: Optional description overriding the block docstring.
+
+    Returns:
+        The rendered prompt for this block type.
+    """
+    context: dict[str, Any] = {
+        "syntax_name": type(syntax).__name__,
+        "syntax_format": syntax.describe_format(),
+        "block": build_block_context(
+            block_class,
+            syntax,
+            include_examples=include_examples,
+            description=description,
+        ),
+    }
+    return TemplateManager().render(context, template_version, mode="single")
+
+
+def build_block_context(
+    block_class: type[Block[Any, Any]],
+    syntax: BaseSyntax,
+    *,
+    include_examples: bool = True,
+    description: str = "",
+) -> dict[str, Any]:
+    """Build the template context describing a single block type."""
+    metadata_class, content_class = extract_block_types(block_class)
+    block_description, block_usage = parse_block_docstring(block_class)
+
+    examples = [syntax.serialize_block(example) for example in block_class.get_examples()] if include_examples else []
+
+    return {
+        "name": infer_block_type_name(block_class),
+        "description": description or block_description,
+        "usage": block_usage,
+        "content_format": inspect_content_format(content_class),
+        "metadata_schema": extract_schema(metadata_class, _METADATA_FIELD),
+        "content_schema": extract_schema(content_class, _CONTENT_FIELD),
+        "examples": examples,
+    }
+
+
+def infer_block_type_name(block_class: type[Block[Any, Any]]) -> str:
+    """Infer the block type name from its metadata, falling back to snake_case."""
+    metadata_class, _ = extract_block_types(block_class)
+    declared = _declared_block_type(metadata_class)
+    return declared if declared is not None else _to_snake_case(block_class.__name__)
+
+
+def _declared_block_type(metadata_class: type[BaseMetadata]) -> str | None:
+    """Read the declared default of the metadata ``block_type`` field."""
+    field = metadata_class.model_fields.get("block_type")
+    default = getattr(field, "default", None)
+    return default if isinstance(default, str) and default else None
+
+
+def _to_snake_case(name: str) -> str:
+    """Convert a CamelCase class name to snake_case."""
+    chars: list[str] = []
+    for index, char in enumerate(name):
+        if char.isupper() and index > 0:
+            chars.append("_")
+        chars.append(char.lower())
+    return "".join(chars)
+
+
+def extract_schema(
+    model_class: type[BaseMetadata | BaseContent],
+    field_type: str,
+    *,
+    exclude_fields: set[str] | None = None,
+) -> dict[str, Any]:
+    """Extract a filtered JSON schema for a metadata or content model."""
+    return filter_schema_fields(model_class.model_json_schema(), field_type, exclude_fields=exclude_fields)
+
+
+def filter_schema_fields(
+    schema: dict[str, Any],
+    field_type: str,
+    *,
+    exclude_fields: set[str] | None = None,
+) -> dict[str, Any]:
+    """Remove auto-populated and caller-excluded fields from a JSON schema."""
+    excluded = set(_ALWAYS_EXCLUDED.get(field_type, set()))
+    if exclude_fields:
+        excluded |= exclude_fields
+
+    if "properties" not in schema:
+        return schema
+
+    filtered = dict(schema)
+    filtered["properties"] = {key: value for key, value in schema["properties"].items() if key not in excluded}
+    if "required" in filtered:
+        filtered["required"] = [name for name in filtered["required"] if name not in excluded]
+    return filtered

--- a/src/hother/streamblocks/prompts/inspector.py
+++ b/src/hother/streamblocks/prompts/inspector.py
@@ -1,0 +1,138 @@
+"""Introspection helpers that turn block classes into prompt fragments."""
+
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from hother.streamblocks.core.types import BaseContent
+
+_DEFAULT_PARSE_MARKER = "Default parse method that just stores raw content"
+_DOCSTRING_SECTION_HEADERS = ("args:", "returns:", "raises:", "example:", "examples:")
+_USAGE_PREFIX = "usage:"
+_USAGE_KEYWORDS = ("use this", "use when", "for ")
+_JSON_FORMAT = "json"
+_YAML_FORMAT = "yaml"
+
+
+def parse_block_docstring(block_class: type) -> tuple[str, str | None]:
+    """Split a block class docstring into (description, usage).
+
+    The first paragraph is the description. Usage is taken from a paragraph
+    starting with "Usage:" or "Use this", falling back to the second paragraph
+    when it reads like usage guidance.
+    """
+    docstring = inspect.getdoc(block_class)
+    if not docstring:
+        return "", None
+
+    paragraphs = _split_paragraphs(docstring)
+    return paragraphs[0], _find_usage(paragraphs)
+
+
+def _split_paragraphs(text: str) -> list[str]:
+    """Collapse a docstring into blank-line-separated paragraphs."""
+    paragraphs: list[str] = []
+    current: list[str] = []
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped:
+            current.append(stripped)
+        elif current:
+            paragraphs.append(" ".join(current))
+            current = []
+    if current:
+        paragraphs.append(" ".join(current))
+    return paragraphs
+
+
+def _find_usage(paragraphs: list[str]) -> str | None:
+    """Locate the usage paragraph among non-leading paragraphs."""
+    for paragraph in paragraphs[1:]:
+        lowered = paragraph.lower()
+        if lowered.startswith(_USAGE_PREFIX):
+            return paragraph[len(_USAGE_PREFIX) :].strip()
+        if lowered.startswith("use this"):
+            return paragraph
+
+    if len(paragraphs) > 1:
+        second = paragraphs[1]
+        if any(keyword in second.lower() for keyword in _USAGE_KEYWORDS):
+            return second
+    return None
+
+
+def inspect_content_format(content_class: type[BaseContent]) -> str | None:
+    """Describe a content class's expected format for prompts.
+
+    Uses the ``__content_format__`` marker set by ``@parse_as_json`` /
+    ``@parse_as_yaml`` when present, otherwise the docstring of a custom
+    ``parse()`` method. Returns None when no format guidance is available.
+    """
+    content_format = getattr(content_class, "__content_format__", None)
+    if content_format in (_JSON_FORMAT, _YAML_FORMAT):
+        return _describe_serialized_format(content_class, content_format)
+    return _describe_custom_parse(content_class)
+
+
+def _describe_custom_parse(content_class: type[BaseContent]) -> str | None:
+    """Extract the description part of a custom parse() docstring, if any."""
+    docstring = inspect.getdoc(content_class.parse)
+    if not docstring or _DEFAULT_PARSE_MARKER in docstring:
+        return None
+
+    description_lines: list[str] = []
+    for line in docstring.split("\n"):
+        if line.strip().lower().startswith(_DOCSTRING_SECTION_HEADERS):
+            break
+        description_lines.append(line)
+
+    description = "\n".join(description_lines).strip()
+    return description or None
+
+
+def _describe_serialized_format(content_class: type[BaseContent], content_format: str) -> str:
+    """Render a JSON/YAML structure hint from a content class's fields."""
+    fields = [(name, info) for name, info in content_class.model_fields.items() if name != "raw_content"]
+    if not fields:
+        return f"Content should be valid {content_format.upper()}"
+
+    lines = [f"Content should be valid {content_format.upper()} with the following structure:", ""]
+    if content_format == _JSON_FORMAT:
+        lines.append("{")
+        last_index = len(fields) - 1
+        for index, (name, info) in enumerate(fields):
+            comma = "," if index < last_index else ""
+            suffix = f"  // {info.description}" if info.description else ""
+            lines.append(f'  "{name}": {_format_type_hint(info.annotation)}{comma}{suffix}')
+        lines.append("}")
+    else:
+        for name, info in fields:
+            suffix = f"  # {info.description}" if info.description else ""
+            lines.append(f"{name}: {_format_type_hint(info.annotation)}{suffix}")
+    return "\n".join(lines)
+
+
+# Ordered (substring, placeholder) pairs. Containers come before scalars
+# because e.g. "list[str]" contains the substring "str".
+_TYPE_PLACEHOLDERS: tuple[tuple[str, str], ...] = (
+    ("list", "[...]"),
+    ("dict", "{...}"),
+    ("bool", "true/false"),
+    ("int", "123"),
+    ("float", "1.23"),
+    ("str", '"string"'),
+)
+
+
+def _format_type_hint(annotation: Any) -> str:
+    """Render a type annotation as a short example placeholder."""
+    if annotation is None:
+        return "any"
+
+    lowered = str(annotation).lower().replace("typing.", "").replace("<class '", "").replace("'>", "")
+    for needle, placeholder in _TYPE_PLACEHOLDERS:
+        if needle in lowered:
+            return placeholder
+    return "..."

--- a/src/hother/streamblocks/prompts/inspector.py
+++ b/src/hother/streamblocks/prompts/inspector.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 _DEFAULT_PARSE_MARKER = "Default parse method that just stores raw content"
 _DOCSTRING_SECTION_HEADERS = ("args:", "returns:", "raises:", "example:", "examples:")
 _USAGE_PREFIX = "usage:"
-_USAGE_KEYWORDS = ("use this", "use when", "for ")
 _JSON_FORMAT = "json"
 _YAML_FORMAT = "yaml"
 
@@ -19,9 +18,9 @@ _YAML_FORMAT = "yaml"
 def parse_block_docstring(block_class: type) -> tuple[str, str | None]:
     """Split a block class docstring into (description, usage).
 
-    The first paragraph is the description. Usage is taken from a paragraph
-    starting with "Usage:" or "Use this", falling back to the second paragraph
-    when it reads like usage guidance.
+    The first paragraph is the description. Usage is taken from a paragraph that
+    explicitly starts with ``Usage:`` (case-insensitive); there is no implicit
+    detection, so block authors opt in to usage guidance via that convention.
     """
     docstring = inspect.getdoc(block_class)
     if not docstring:
@@ -48,18 +47,10 @@ def _split_paragraphs(text: str) -> list[str]:
 
 
 def _find_usage(paragraphs: list[str]) -> str | None:
-    """Locate the usage paragraph among non-leading paragraphs."""
+    """Return the explicit ``Usage:`` paragraph (without its prefix), if any."""
     for paragraph in paragraphs[1:]:
-        lowered = paragraph.lower()
-        if lowered.startswith(_USAGE_PREFIX):
+        if paragraph.lower().startswith(_USAGE_PREFIX):
             return paragraph[len(_USAGE_PREFIX) :].strip()
-        if lowered.startswith("use this"):
-            return paragraph
-
-    if len(paragraphs) > 1:
-        second = paragraphs[1]
-        if any(keyword in second.lower() for keyword in _USAGE_KEYWORDS):
-            return second
     return None
 
 

--- a/src/hother/streamblocks/prompts/manager.py
+++ b/src/hother/streamblocks/prompts/manager.py
@@ -1,0 +1,69 @@
+"""Jinja2 template management for prompt generation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from jinja2 import Environment, PackageLoader, Template
+
+if TYPE_CHECKING:
+    from typing import Any
+
+# Template render modes
+_MODE_REGISTRY = "registry"
+_MODE_SINGLE = "single"
+_MODE_BOTH = "both"
+_DEFAULT_VERSION = "default"
+
+
+class TemplateManager:
+    """Manage Jinja2 templates with version support for prompt A/B testing.
+
+    Built-in templates live in the package ``templates/`` directory and are
+    named ``<mode>.jinja2`` (default version) or ``<mode>_<version>.jinja2``.
+    Custom templates can be registered at runtime via :meth:`register_template`.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the manager with the package template loader."""
+        self._custom_templates: dict[tuple[str, str], Template] = {}
+        self._env = Environment(
+            loader=PackageLoader("hother.streamblocks.prompts", "templates"),
+            autoescape=False,
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+
+    def register_template(self, version: str, template: str | Path, mode: str = _MODE_BOTH) -> None:
+        """Register a custom template for one or both render modes.
+
+        Args:
+            version: Version identifier (e.g. "concise").
+            template: Template string, or a Path to a template file.
+            mode: "registry", "single", or "both".
+        """
+        template_str = template.read_text(encoding="utf-8") if isinstance(template, Path) else template
+        template_obj = Template(template_str, autoescape=False, trim_blocks=True, lstrip_blocks=True)
+
+        if mode in (_MODE_REGISTRY, _MODE_BOTH):
+            self._custom_templates[(_MODE_REGISTRY, version)] = template_obj
+        if mode in (_MODE_SINGLE, _MODE_BOTH):
+            self._custom_templates[(_MODE_SINGLE, version)] = template_obj
+
+    def get_template(self, version: str = _DEFAULT_VERSION, mode: str = _MODE_REGISTRY) -> Template:
+        """Return the template for the given version and mode.
+
+        Custom-registered templates take priority over built-in package
+        templates.
+        """
+        custom = self._custom_templates.get((mode, version))
+        if custom is not None:
+            return custom
+
+        filename = f"{mode}.jinja2" if version == _DEFAULT_VERSION else f"{mode}_{version}.jinja2"
+        return self._env.get_template(filename)
+
+    def render(self, context: dict[str, Any], version: str = _DEFAULT_VERSION, mode: str = _MODE_REGISTRY) -> str:
+        """Render the resolved template with the given context."""
+        return self.get_template(version, mode).render(context)

--- a/src/hother/streamblocks/prompts/templates/registry.jinja2
+++ b/src/hother/streamblocks/prompts/templates/registry.jinja2
@@ -1,0 +1,59 @@
+# Structured Block Output Format
+
+You can output structured blocks using the {{ syntax_name }}.
+
+## Syntax Format
+
+{{ syntax_format }}
+
+## Available Block Types
+
+You can output the following types of blocks:
+
+{% for block in blocks %}
+### {{ block.name }}
+
+{% if block.description %}
+{{ block.description }}
+
+{% if block.usage %}
+{{ block.usage }}
+{% endif %}
+{% endif %}
+{% if block.content_format %}
+**Content Format:**
+
+{{ block.content_format }}
+{% endif %}
+{% if block.metadata_schema.properties %}
+**Metadata Fields:**
+{% for field_name, field_info in block.metadata_schema.properties.items() %}
+{% if field_info.description %}
+- `{{ field_name }}` - {{ field_info.description }}
+{% else %}
+- `{{ field_name }}`
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if block.examples %}
+**Examples:**
+
+{% for example in block.examples %}
+```
+{{ example }}
+```
+
+{% endfor %}
+{% endif %}
+
+---
+
+{% endfor %}
+
+## Usage Guidelines
+
+1. Always use the exact syntax format shown above
+2. Ensure all required metadata fields are included
+3. Content should be formatted according to the content format specification
+4. Block IDs should be unique within the conversation
+5. Use the appropriate block type for your intent

--- a/src/hother/streamblocks/prompts/templates/single.jinja2
+++ b/src/hother/streamblocks/prompts/templates/single.jinja2
@@ -1,0 +1,43 @@
+# {{ block.name }} Block
+
+You can output a `{{ block.name }}` block using the {{ syntax_name }}.
+
+## Syntax Format
+
+{{ syntax_format }}
+
+{% if block.description %}
+## Description
+
+{{ block.description }}
+
+{% if block.usage %}
+{{ block.usage }}
+{% endif %}
+{% endif %}
+{% if block.content_format %}
+## Content Format
+
+{{ block.content_format }}
+{% endif %}
+{% if block.metadata_schema.properties %}
+## Metadata Fields
+
+{% for field_name, field_info in block.metadata_schema.properties.items() %}
+{% if field_info.description %}
+- `{{ field_name }}` - {{ field_info.description }}
+{% else %}
+- `{{ field_name }}`
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if block.examples %}
+## Examples
+
+{% for example in block.examples %}
+```
+{{ example }}
+```
+
+{% endfor %}
+{% endif %}

--- a/src/hother/streamblocks/syntaxes/base.py
+++ b/src/hother/streamblocks/syntaxes/base.py
@@ -13,7 +13,7 @@ from pydantic import ValidationError
 from hother.streamblocks.core.types import BaseMetadata, ParseResult
 
 if TYPE_CHECKING:
-    from hother.streamblocks.core.models import BlockCandidate, ExtractedBlock
+    from hother.streamblocks.core.models import Block, BlockCandidate, ExtractedBlock
     from hother.streamblocks.core.types import BaseContent, DetectionResult
 
 # Module-level logger for debugging YAML parsing failures
@@ -295,3 +295,37 @@ class BaseSyntax(ABC):
             or failed
         """
         return None
+
+    # Serialization and documentation (used by prompt generation)
+
+    def serialize_block(self, block: Block[BaseMetadata, BaseContent]) -> str:
+        """Serialize a block instance back to this syntax's textual form.
+
+        Used by prompt generation to render examples in the exact format the
+        model is expected to produce. The shipped syntaxes override this.
+        Custom syntaxes that want example rendering in prompts should override
+        it as well.
+
+        Args:
+            block: Block instance to serialize
+
+        Returns:
+            The block rendered in this syntax's text format
+
+        Raises:
+            NotImplementedError: If the concrete syntax does not implement it
+        """
+        msg = f"{type(self).__name__} does not implement serialize_block()"
+        raise NotImplementedError(msg)
+
+    def describe_format(self) -> str:
+        """Return a human-readable description of this syntax's block format.
+
+        Used in generated prompts to teach the model the block format. The
+        default returns a minimal description; shipped syntaxes override it
+        with a concrete format specification.
+
+        Returns:
+            A description of the block format for this syntax
+        """
+        return f"{type(self).__name__}: no format description available."

--- a/src/hother/streamblocks/syntaxes/delimiter.py
+++ b/src/hother/streamblocks/syntaxes/delimiter.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+import yaml
+
 from hother.streamblocks.core.models import extract_block_types
 from hother.streamblocks.core.types import BaseContent, BaseMetadata, DetectionResult, ParseResult, SectionType
 from hother.streamblocks.syntaxes.base import BaseSyntax, YAMLFrontmatterMixin
 
 if TYPE_CHECKING:
-    from hother.streamblocks.core.models import BlockCandidate, ExtractedBlock
+    from hother.streamblocks.core.models import Block, BlockCandidate, ExtractedBlock
 
 # Minimum lines required for a block (header + closing delimiter)
 _MIN_BLOCK_LINES = 2
@@ -197,6 +199,50 @@ class DelimiterPreambleSyntax(BaseSyntax):
         raw_content = "\n".join(content_lines)
         return {"raw_content": raw_content}
 
+    def serialize_block(self, block: Block[BaseMetadata, BaseContent]) -> str:
+        """Serialize a block to delimiter preamble format.
+
+        Produces the round-trip form of this syntax::
+
+            !!<id>:<type>[:<param_0>:<param_1>...]
+            <raw content>
+            !!end
+
+        Args:
+            block: Block instance to serialize
+
+        Returns:
+            The block rendered in delimiter preamble format
+        """
+        metadata = block.metadata
+        opening = f"{self.delimiter}{metadata.id}:{metadata.block_type}"
+
+        # Re-emit positional params (param_0, param_1, ...) if present
+        params: list[str] = []
+        index = 0
+        while hasattr(metadata, f"param_{index}"):
+            params.append(str(getattr(metadata, f"param_{index}")))
+            index += 1
+        if params:
+            opening += ":" + ":".join(params)
+
+        return f"{opening}\n{block.content.raw_content}\n{self.delimiter}end"
+
+    def describe_format(self) -> str:
+        """Describe the delimiter preamble format for prompts."""
+        return (
+            "Delimiter Preamble Syntax\n\n"
+            "Format:\n"
+            f"{self.delimiter}<id>:<type>[:<param1>:<param2>...]\n"
+            "content lines\n"
+            f"{self.delimiter}end\n\n"
+            "Components:\n"
+            f"- Opening line: {self.delimiter}<id>:<type> where id is unique and type identifies the block\n"
+            "- Optional parameters: additional colon-separated values after type\n"
+            "- Content: any text between the opening and closing markers\n"
+            f"- Closing line: {self.delimiter}end"
+        )
+
 
 class DelimiterFrontmatterSyntax(BaseSyntax, YAMLFrontmatterMixin):
     """Syntax: Delimiter markers with YAML frontmatter.
@@ -357,3 +403,42 @@ class DelimiterFrontmatterSyntax(BaseSyntax, YAMLFrontmatterMixin):
         """
         raw_content = "\n".join(candidate.content_lines)
         return {"raw_content": raw_content}
+
+    def serialize_block(self, block: Block[BaseMetadata, BaseContent]) -> str:
+        """Serialize a block to delimiter frontmatter format.
+
+        Produces the round-trip form of this syntax::
+
+            !!start
+            ---
+            <yaml metadata>
+            ---
+            <raw content>
+            !!end
+
+        Args:
+            block: Block instance to serialize
+
+        Returns:
+            The block rendered in delimiter frontmatter format
+        """
+        metadata_yaml = yaml.dump(block.metadata.model_dump(), default_flow_style=False, sort_keys=False)
+        return f"{self.start_delimiter}\n---\n{metadata_yaml}---\n{block.content.raw_content}\n{self.end_delimiter}"
+
+    def describe_format(self) -> str:
+        """Describe the delimiter frontmatter format for prompts."""
+        return (
+            "Delimiter Frontmatter Syntax\n\n"
+            "Format:\n"
+            f"{self.start_delimiter}\n"
+            "---\n"
+            "key: value\n"
+            "---\n"
+            "content lines\n"
+            f"{self.end_delimiter}\n\n"
+            "Components:\n"
+            f"- Opening marker: {self.start_delimiter}\n"
+            "- Metadata section: YAML frontmatter between --- delimiters\n"
+            "- Content: any text after the metadata section\n"
+            f"- Closing marker: {self.end_delimiter}"
+        )

--- a/src/hother/streamblocks/syntaxes/markdown.py
+++ b/src/hother/streamblocks/syntaxes/markdown.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
+import yaml
+
 from hother.streamblocks.core.models import extract_block_types
 from hother.streamblocks.core.types import BaseContent, BaseMetadata, DetectionResult, ParseResult, SectionType
 from hother.streamblocks.syntaxes.base import BaseSyntax, YAMLFrontmatterMixin
 
 if TYPE_CHECKING:
-    from hother.streamblocks.core.models import BlockCandidate, ExtractedBlock
+    from hother.streamblocks.core.models import Block, BlockCandidate, ExtractedBlock
 
 
 class MarkdownFrontmatterSyntax(BaseSyntax, YAMLFrontmatterMixin):
@@ -198,3 +200,44 @@ class MarkdownFrontmatterSyntax(BaseSyntax, YAMLFrontmatterMixin):
     def validate_block(self, _block: ExtractedBlock[BaseMetadata, BaseContent]) -> bool:
         """Additional validation after parsing."""
         return True
+
+    def serialize_block(self, block: Block[BaseMetadata, BaseContent]) -> str:
+        """Serialize a block to markdown frontmatter format.
+
+        Produces the round-trip form of this syntax::
+
+            ```[info_string]
+            ---
+            <yaml metadata>
+            ---
+            <raw content>
+            ```
+
+        Args:
+            block: Block instance to serialize
+
+        Returns:
+            The block rendered in markdown frontmatter format
+        """
+        metadata_yaml = yaml.dump(block.metadata.model_dump(), default_flow_style=False, sort_keys=False)
+        opening = f"{self.fence}{self.info_string}" if self.info_string else self.fence
+        return f"{opening}\n---\n{metadata_yaml}---\n{block.content.raw_content}\n{self.fence}"
+
+    def describe_format(self) -> str:
+        """Describe the markdown frontmatter format for prompts."""
+        info_str_desc = f"{self.info_string}" if self.info_string else "[info_string]"
+        return (
+            "Markdown Frontmatter Syntax\n\n"
+            "Format:\n"
+            f"{self.fence}{info_str_desc}\n"
+            "---\n"
+            "key: value\n"
+            "---\n"
+            "content lines\n"
+            f"{self.fence}\n\n"
+            "Components:\n"
+            f"- Opening fence: {self.fence} with optional info string\n"
+            "- Metadata section: YAML frontmatter between --- delimiters\n"
+            "- Content: any text after the metadata section\n"
+            f"- Closing fence: {self.fence}"
+        )

--- a/src/hother/streamblocks_examples/01_basics/07_prompt_generation.py
+++ b/src/hother/streamblocks_examples/01_basics/07_prompt_generation.py
@@ -1,0 +1,87 @@
+"""Generate LLM system prompts from a block registry.
+
+Shows ``Registry.to_prompt()``, single-block ``generate_block_prompt()``, and a
+custom prompt template. Everything runs offline -- no LLM calls -- because the
+prompt is built purely from the block definitions (docstring, metadata fields,
+content format, and examples).
+"""
+
+# --8<-- [start:imports]
+from typing import ClassVar, Literal
+
+from hother.streamblocks import (
+    BaseContent,
+    BaseMetadata,
+    Block,
+    DelimiterFrontmatterSyntax,
+    Registry,
+    generate_block_prompt,
+    parse_as_yaml,
+)
+
+# --8<-- [end:imports]
+
+
+# --8<-- [start:blocks]
+class SearchMetadata(BaseMetadata):
+    """Metadata for a catalog search block."""
+
+    block_type: Literal["search"] = "search"
+
+
+@parse_as_yaml()
+class SearchContent(BaseContent):
+    """Search parameters."""
+
+    query: str = ""
+    limit: int = 10
+
+
+class Search(Block[SearchMetadata, SearchContent]):
+    """Search the product catalog.
+
+    Usage: emit a search block to look up products before answering.
+    """
+
+    # Declared examples are serialized into the prompt so the model sees a
+    # concrete, correctly-formatted block.
+    __examples__: ClassVar[list[dict[str, object]]] = [
+        {
+            "metadata": {"id": "s1", "block_type": "search"},
+            "content": {"query": "wireless headphones", "limit": 5},
+        },
+    ]
+
+
+# --8<-- [end:blocks]
+
+
+def main() -> None:
+    """Build prompts from a registry and print them."""
+    # --8<-- [start:registry_prompt]
+    registry = Registry(syntax=DelimiterFrontmatterSyntax())
+    registry.register("search", Search)
+
+    # A full system prompt documenting every registered block: the syntax
+    # format, the block description + "Usage:" line, its metadata fields, the
+    # YAML content format (from @parse_as_yaml), and serialized examples.
+    prompt = registry.to_prompt()
+    print(prompt)
+    # --8<-- [end:registry_prompt]
+
+    # --8<-- [start:single]
+    # A prompt for a single block type -- here without the examples section.
+    single = generate_block_prompt(Search, registry.syntax, include_examples=False)
+    print(single)
+    # --8<-- [end:single]
+
+    # --8<-- [start:templates]
+    # Register a custom template and select it with template_version. Templates
+    # receive `syntax_name`, `syntax_format`, and `blocks` in their context.
+    registry.register_template("compact", "Available blocks: {{ blocks | length }}", mode="registry")
+    print(registry.to_prompt(template_version="compact"))
+    # --8<-- [end:templates]
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_block_examples.py
+++ b/tests/test_block_examples.py
@@ -1,0 +1,172 @@
+"""Tests for the Block examples mechanism (inline, dynamic, and file-based)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import pytest
+
+from hother.streamblocks.core.models import Block
+from hother.streamblocks.core.parsing import parse_as_yaml
+from hother.streamblocks.core.types import BaseContent, BaseMetadata
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class GreetMeta(BaseMetadata):
+    block_type: Literal["greet"] = "greet"
+
+
+@parse_as_yaml()
+class GreetContent(BaseContent):
+    name: str = ""
+
+
+class PlainContent(BaseContent):
+    pass
+
+
+def _make_block_class() -> type[Block[GreetMeta, GreetContent]]:
+    """A fresh Greet subclass so example caches/storage don't leak across tests."""
+
+    class Greet(Block[GreetMeta, GreetContent]):
+        """Greet someone."""
+
+    return Greet
+
+
+def test_inline_example_autofills_yaml_raw_content() -> None:
+    block_cls = _make_block_class()
+    block_cls.__examples__ = [{"metadata": {"id": "g1", "block_type": "greet"}, "content": {"name": "Ada"}}]
+    examples = block_cls.get_examples()
+    assert len(examples) == 1
+    assert examples[0].content.raw_content == "name: Ada"
+
+
+def test_inline_example_autofills_json_raw_content() -> None:
+    class JsonMeta(BaseMetadata):
+        block_type: Literal["plain"] = "plain"
+
+    class PlainBlock(Block[JsonMeta, PlainContent]):
+        """Plain block (defaults to JSON serialization)."""
+
+    PlainBlock.__examples__ = [{"metadata": {"id": "p1", "block_type": "plain"}, "content": {"value": "hi"}}]
+    assert PlainBlock.get_examples()[0].content.raw_content == '{"value": "hi"}'
+
+
+def test_inline_example_honors_explicit_raw_content() -> None:
+    block_cls = _make_block_class()
+    block_cls.__examples__ = [
+        {"metadata": {"id": "g1", "block_type": "greet"}, "content": {"name": "Ada", "raw_content": "custom"}},
+    ]
+    assert block_cls.get_examples()[0].content.raw_content == "custom"
+
+
+def test_add_example_dict_and_instance() -> None:
+    block_cls = _make_block_class()
+    block_cls.add_example({"metadata": {"id": "d1", "block_type": "greet"}, "content": {"name": "Bo"}})
+    block_cls.add_example(block_cls(metadata=GreetMeta(id="d2"), content=GreetContent(raw_content="x")))
+    assert {ex.metadata.id for ex in block_cls.get_examples()} == {"d1", "d2"}
+
+
+def test_add_examples_and_clear() -> None:
+    block_cls = _make_block_class()
+    block_cls.add_examples(
+        [
+            {"metadata": {"id": "a", "block_type": "greet"}, "content": {"name": "A"}},
+            {"metadata": {"id": "b", "block_type": "greet"}, "content": {"name": "B"}},
+        ]
+    )
+    assert len(block_cls.get_examples()) == 2
+    block_cls.clear_examples()
+    assert block_cls.get_examples() == []
+
+
+def test_add_example_with_content_instance_skips_autofill() -> None:
+    block_cls = _make_block_class()
+    block_cls.add_example({"metadata": {"id": "i1", "block_type": "greet"}, "content": GreetContent(raw_content="rc")})
+    assert block_cls.get_examples()[0].content.raw_content == "rc"
+
+
+_FILE_HEADER = "---\nsyntax: DELIMITER_FRONTMATTER\n---\n\n"
+_VALID_BLOCK = "!!start\n---\nid: ex1\nblock_type: greet\n---\nname: Bob\n!!end\n"
+
+
+def _write(tmp_path: Path, body: str, name: str = "examples.md") -> Path:
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_file_examples_load_and_cache(tmp_path: Path) -> None:
+    block_cls = _make_block_class()
+    block_cls.__examples__ = _write(tmp_path, _FILE_HEADER + _VALID_BLOCK)
+    first = block_cls.get_examples()
+    second = block_cls.get_examples()  # second call hits the mtime cache
+    assert first[0].metadata.id == "ex1"
+    assert first[0].content.name == "Bob"
+    assert [e.metadata.id for e in second] == ["ex1"]
+
+
+def test_file_examples_with_leading_prose(tmp_path: Path) -> None:
+    block_cls = _make_block_class()
+    body = _FILE_HEADER + "Some intro prose before the block.\n\n" + _VALID_BLOCK
+    block_cls.__examples__ = _write(tmp_path, body)
+    assert block_cls.get_examples()[0].metadata.id == "ex1"
+
+
+def test_file_examples_as_string_path(tmp_path: Path) -> None:
+    block_cls = _make_block_class()
+    block_cls.__examples__ = str(_write(tmp_path, _FILE_HEADER + _VALID_BLOCK))
+    assert block_cls.get_examples()[0].metadata.id == "ex1"
+
+
+def test_file_examples_missing_file() -> None:
+    block_cls = _make_block_class()
+    block_cls.__examples__ = "/nonexistent/path/examples.md"
+    with pytest.raises(FileNotFoundError):
+        block_cls.get_examples()
+
+
+def test_file_examples_no_frontmatter(tmp_path: Path) -> None:
+    block_cls = _make_block_class()
+    block_cls.__examples__ = _write(tmp_path, "no frontmatter here")
+    with pytest.raises(ValueError, match="must start with YAML frontmatter"):
+        block_cls.get_examples()
+
+
+def test_file_examples_incomplete_frontmatter(tmp_path: Path) -> None:
+    block_cls = _make_block_class()
+    block_cls.__examples__ = _write(tmp_path, "---\nsyntax: DELIMITER_FRONTMATTER\n")
+    with pytest.raises(ValueError, match="Invalid frontmatter"):
+        block_cls.get_examples()
+
+
+def test_file_examples_non_mapping_frontmatter(tmp_path: Path) -> None:
+    block_cls = _make_block_class()
+    block_cls.__examples__ = _write(tmp_path, "---\n- just\n- a list\n---\nbody")
+    with pytest.raises(TypeError, match="must be a YAML mapping"):
+        block_cls.get_examples()
+
+
+def test_file_examples_non_string_syntax(tmp_path: Path) -> None:
+    block_cls = _make_block_class()
+    block_cls.__examples__ = _write(tmp_path, "---\nsyntax: 123\n---\nbody")
+    with pytest.raises(TypeError, match="name a string 'syntax' field"):
+        block_cls.get_examples()
+
+
+def test_file_examples_unknown_syntax(tmp_path: Path) -> None:
+    block_cls = _make_block_class()
+    block_cls.__examples__ = _write(tmp_path, "---\nsyntax: NOPE\n---\nbody")
+    with pytest.raises(ValueError, match="Unknown syntax"):
+        block_cls.get_examples()
+
+
+def test_file_examples_unparseable_block_raises(tmp_path: Path) -> None:
+    block_cls = _make_block_class()
+    bad_block = "!!start\n---\nblock_type: greet\n---\nname: Bob\n!!end\n"  # missing required id
+    block_cls.__examples__ = _write(tmp_path, _FILE_HEADER + bad_block)
+    with pytest.raises(ValueError, match="Failed to parse example block"):
+        block_cls.get_examples()

--- a/tests/test_prompts_builder.py
+++ b/tests/test_prompts_builder.py
@@ -31,7 +31,7 @@ class GreetContent(BaseContent):
 class Greet(Block[GreetMeta, GreetContent]):
     """Greet someone.
 
-    Use this block to greet a person by name.
+    Usage: greet a person by name.
     """
 
     __examples__ = [
@@ -59,7 +59,7 @@ def test_build_block_context_includes_examples_and_format() -> None:
     context = build_block_context(Greet, DelimiterPreambleSyntax())
     assert context["name"] == "greet"
     assert context["description"] == "Greet someone."
-    assert context["usage"] == "Use this block to greet a person by name."
+    assert context["usage"] == "greet a person by name."
     assert context["content_format"] is not None
     assert context["metadata_schema"]["properties"].keys() == {"tone"}
     assert context["examples"] == ["!!g1:greet\nname: Ada\n!!end"]

--- a/tests/test_prompts_builder.py
+++ b/tests/test_prompts_builder.py
@@ -1,0 +1,144 @@
+"""Tests for prompt builder helpers and Registry prompt generation."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from hother.streamblocks.core.models import Block
+from hother.streamblocks.core.parsing import parse_as_yaml
+from hother.streamblocks.core.registry import Registry
+from hother.streamblocks.core.types import BaseContent, BaseMetadata
+from hother.streamblocks.prompts.builder import (
+    build_block_context,
+    extract_schema,
+    filter_schema_fields,
+    generate_block_prompt,
+    infer_block_type_name,
+)
+from hother.streamblocks.syntaxes.delimiter import DelimiterFrontmatterSyntax, DelimiterPreambleSyntax
+
+
+class GreetMeta(BaseMetadata):
+    block_type: Literal["greet"] = "greet"
+    tone: str | None = None
+
+
+@parse_as_yaml()
+class GreetContent(BaseContent):
+    name: str = ""
+
+
+class Greet(Block[GreetMeta, GreetContent]):
+    """Greet someone.
+
+    Use this block to greet a person by name.
+    """
+
+    __examples__ = [
+        {"metadata": {"id": "g1", "block_type": "greet", "tone": "warm"}, "content": {"name": "Ada"}},
+    ]
+
+
+class NoDefaultMeta(BaseMetadata):
+    block_type: str
+
+
+class CamelCaseThing(Block[NoDefaultMeta, BaseContent]):
+    """A block whose type name is inferred from the class name."""
+
+
+def test_infer_block_type_from_declared_default() -> None:
+    assert infer_block_type_name(Greet) == "greet"
+
+
+def test_infer_block_type_snake_case_fallback() -> None:
+    assert infer_block_type_name(CamelCaseThing) == "camel_case_thing"
+
+
+def test_build_block_context_includes_examples_and_format() -> None:
+    context = build_block_context(Greet, DelimiterPreambleSyntax())
+    assert context["name"] == "greet"
+    assert context["description"] == "Greet someone."
+    assert context["usage"] == "Use this block to greet a person by name."
+    assert context["content_format"] is not None
+    assert context["metadata_schema"]["properties"].keys() == {"tone"}
+    assert context["examples"] == ["!!g1:greet\nname: Ada\n!!end"]
+
+
+def test_build_block_context_without_examples() -> None:
+    context = build_block_context(Greet, DelimiterPreambleSyntax(), include_examples=False)
+    assert context["examples"] == []
+
+
+def test_build_block_context_description_override() -> None:
+    context = build_block_context(Greet, DelimiterPreambleSyntax(), description="Custom.")
+    assert context["description"] == "Custom."
+
+
+def test_generate_block_prompt_single() -> None:
+    prompt = generate_block_prompt(Greet, DelimiterPreambleSyntax())
+    assert "# greet Block" in prompt
+    assert "Delimiter Preamble Syntax" in prompt
+    assert "!!g1:greet" in prompt
+
+
+def test_extract_schema_excludes_base_fields() -> None:
+    schema = extract_schema(GreetMeta, "metadata")
+    assert "id" not in schema["properties"]
+    assert "block_type" not in schema["properties"]
+    assert "tone" in schema["properties"]
+
+
+def test_extract_schema_with_extra_excludes() -> None:
+    schema = extract_schema(GreetMeta, "metadata", exclude_fields={"tone"})
+    assert schema["properties"] == {}
+
+
+def test_filter_schema_without_properties_returns_input() -> None:
+    schema = {"type": "object"}
+    assert filter_schema_fields(schema, "metadata") == {"type": "object"}
+
+
+def test_filter_schema_without_required_key() -> None:
+    result = filter_schema_fields({"properties": {"a": {}, "id": {}}}, "metadata")
+    assert result["properties"] == {"a": {}}
+    assert "required" not in result
+
+
+def test_filter_schema_filters_required_list() -> None:
+    schema = {
+        "properties": {"id": {}, "block_type": {}, "tone": {}},
+        "required": ["id", "block_type", "tone"],
+    }
+    result = filter_schema_fields(schema, "metadata")
+    assert result["properties"] == {"tone": {}}
+    assert result["required"] == ["tone"]
+
+
+def test_registry_to_prompt_lists_blocks() -> None:
+    registry = Registry(syntax=DelimiterFrontmatterSyntax())
+    registry.register("greet", Greet)
+    prompt = registry.to_prompt()
+    assert "## Available Block Types" in prompt
+    assert "### greet" in prompt
+    assert "Delimiter Frontmatter Syntax" in prompt
+
+
+def test_registry_registered_blocks_is_readonly_view() -> None:
+    registry = Registry()
+    registry.register("greet", Greet)
+    blocks = registry.registered_blocks
+    assert dict(blocks) == {"greet": Greet}
+
+
+def test_registry_serialize_block() -> None:
+    registry = Registry(syntax=DelimiterPreambleSyntax())
+    block = Greet.get_examples()[0]
+    assert registry.serialize_block(block) == "!!g1:greet\nname: Ada\n!!end"
+
+
+def test_registry_custom_template() -> None:
+    registry = Registry(syntax=DelimiterPreambleSyntax())
+    registry.register("greet", Greet)
+    registry.register_template("concise", "BLOCKS: {{ blocks | length }}", mode="registry")
+    assert registry.to_prompt(template_version="concise") == "BLOCKS: 1"

--- a/tests/test_prompts_inspector.py
+++ b/tests/test_prompts_inspector.py
@@ -66,19 +66,15 @@ def test_parse_docstring_usage_prefix() -> None:
     assert usage == "do the thing carefully."
 
 
-def test_parse_docstring_use_this() -> None:
+def test_parse_docstring_use_this_is_not_implicit_usage() -> None:
+    # Only an explicit "Usage:" paragraph counts; "Use this..." is not detected.
     _, usage = parse_block_docstring(UseThis)
-    assert usage == "Use this when you need the thing."
-
-
-def test_parse_docstring_keyword_fallback() -> None:
-    _, usage = parse_block_docstring(KeywordFallback)
-    assert usage == "For advanced scenarios only."
-
-
-def test_parse_docstring_second_without_keyword_has_no_usage() -> None:
-    _, usage = parse_block_docstring(SecondNoKeyword)
     assert usage is None
+
+
+def test_parse_docstring_non_usage_paragraph_has_no_usage() -> None:
+    assert parse_block_docstring(KeywordFallback)[1] is None
+    assert parse_block_docstring(SecondNoKeyword)[1] is None
 
 
 @parse_as_json()

--- a/tests/test_prompts_inspector.py
+++ b/tests/test_prompts_inspector.py
@@ -1,0 +1,179 @@
+"""Tests for prompt inspector helpers."""
+
+from __future__ import annotations
+
+from typing import Self
+
+import pytest
+
+from hother.streamblocks.core.parsing import parse_as_json, parse_as_yaml
+from hother.streamblocks.core.types import BaseContent
+from hother.streamblocks.prompts.inspector import (
+    _format_type_hint,
+    _split_paragraphs,
+    inspect_content_format,
+    parse_block_docstring,
+)
+
+
+class NoDoc:
+    pass
+
+
+class DescOnly:
+    """Just a description."""
+
+
+class UsagePrefix:
+    """A description.
+
+    Usage: do the thing carefully.
+    """
+
+
+class UseThis:
+    """A description.
+
+    Use this when you need the thing.
+    """
+
+
+class KeywordFallback:
+    """A description.
+
+    For advanced scenarios only.
+    """
+
+
+class SecondNoKeyword:
+    """A description.
+
+    Totally unrelated second paragraph.
+    """
+
+
+def test_parse_docstring_none() -> None:
+    assert parse_block_docstring(NoDoc) == ("", None)
+
+
+def test_parse_docstring_description_only() -> None:
+    assert parse_block_docstring(DescOnly) == ("Just a description.", None)
+
+
+def test_parse_docstring_usage_prefix() -> None:
+    description, usage = parse_block_docstring(UsagePrefix)
+    assert description == "A description."
+    assert usage == "do the thing carefully."
+
+
+def test_parse_docstring_use_this() -> None:
+    _, usage = parse_block_docstring(UseThis)
+    assert usage == "Use this when you need the thing."
+
+
+def test_parse_docstring_keyword_fallback() -> None:
+    _, usage = parse_block_docstring(KeywordFallback)
+    assert usage == "For advanced scenarios only."
+
+
+def test_parse_docstring_second_without_keyword_has_no_usage() -> None:
+    _, usage = parse_block_docstring(SecondNoKeyword)
+    assert usage is None
+
+
+@parse_as_json()
+class JsonContent(BaseContent):
+    status: int = 0
+    label: str = ""
+
+
+@parse_as_yaml()
+class YamlContent(BaseContent):
+    name: str = ""
+
+
+@parse_as_json()
+class EmptyJsonContent(BaseContent):
+    pass
+
+
+class CustomParseContent(BaseContent):
+    @classmethod
+    def parse(cls, raw_text: str) -> Self:
+        """Parse the colon separated form.
+
+        Args:
+            raw_text: the text.
+        """
+        return cls(raw_content=raw_text)
+
+
+class NoDocParseContent(BaseContent):
+    @classmethod
+    def parse(cls, raw_text: str) -> Self:
+        return cls(raw_content=raw_text)
+
+
+class SectionlessParseContent(BaseContent):
+    @classmethod
+    def parse(cls, raw_text: str) -> Self:
+        """Just a description without sections."""
+        return cls(raw_content=raw_text)
+
+
+def test_split_paragraphs_handles_repeated_and_trailing_blanks() -> None:
+    # Repeated blanks (blank while no paragraph buffered) and a trailing blank.
+    assert _split_paragraphs("a\n\nb\n\n") == ["a", "b"]
+
+
+def test_inspect_json_format_lists_fields() -> None:
+    result = inspect_content_format(JsonContent)
+    assert result is not None
+    assert "valid JSON" in result
+    assert '"status"' in result
+    assert '"label"' in result
+
+
+def test_inspect_yaml_format() -> None:
+    result = inspect_content_format(YamlContent)
+    assert result is not None
+    assert "valid YAML" in result
+    assert "name:" in result
+
+
+def test_inspect_json_format_no_extra_fields() -> None:
+    assert inspect_content_format(EmptyJsonContent) == "Content should be valid JSON"
+
+
+def test_inspect_custom_parse_docstring() -> None:
+    result = inspect_content_format(CustomParseContent)
+    assert result == "Parse the colon separated form."
+
+
+def test_inspect_default_parse_returns_none() -> None:
+    assert inspect_content_format(BaseContent) is None
+
+
+def test_inspect_custom_parse_without_docstring_returns_none() -> None:
+    assert inspect_content_format(NoDocParseContent) is None
+
+
+def test_inspect_custom_parse_without_sections() -> None:
+    assert inspect_content_format(SectionlessParseContent) == "Just a description without sections."
+
+
+@pytest.mark.parametrize(
+    ("annotation", "expected"),
+    [
+        (None, "any"),
+        (bool, "true/false"),
+        (int, "123"),
+        (float, "1.23"),
+        (str, '"string"'),
+        (list[str], "[...]"),
+        (dict[str, int], "{...}"),
+        (bytes, "..."),
+    ],
+)
+def test_format_type_hint(annotation: object, expected: str) -> None:
+    assert _format_type_hint(annotation) == expected

--- a/tests/test_prompts_manager.py
+++ b/tests/test_prompts_manager.py
@@ -1,0 +1,61 @@
+"""Tests for the Jinja2 TemplateManager."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from jinja2 import TemplateNotFound
+
+from hother.streamblocks.prompts.manager import TemplateManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_render_default_registry_template() -> None:
+    manager = TemplateManager()
+    output = manager.render(
+        {"syntax_name": "X", "syntax_format": "fmt", "blocks": []},
+        mode="registry",
+    )
+    assert "# Structured Block Output Format" in output
+
+
+def test_render_default_single_template() -> None:
+    manager = TemplateManager()
+    block = {
+        "name": "demo",
+        "description": "",
+        "usage": None,
+        "content_format": None,
+        "metadata_schema": {},
+        "examples": [],
+    }
+    output = manager.render(
+        {"syntax_name": "X", "syntax_format": "fmt", "block": block},
+        mode="single",
+    )
+    assert "# demo Block" in output
+
+
+def test_register_and_render_custom_string_template() -> None:
+    manager = TemplateManager()
+    manager.register_template("v2", "name={{ block.name }}", mode="single")
+    output = manager.render({"block": {"name": "demo"}}, version="v2", mode="single")
+    assert output == "name=demo"
+
+
+def test_register_custom_template_from_path(tmp_path: Path) -> None:
+    template_file = tmp_path / "tpl.jinja2"
+    template_file.write_text("count={{ blocks | length }}", encoding="utf-8")
+    manager = TemplateManager()
+    manager.register_template("file", template_file, mode="both")
+    assert manager.render({"blocks": [1, 2]}, version="file", mode="registry") == "count=2"
+    assert manager.render({"blocks": [1, 2]}, version="file", mode="single") == "count=2"
+
+
+def test_unknown_package_version_raises() -> None:
+    manager = TemplateManager()
+    with pytest.raises(TemplateNotFound):
+        manager.get_template(version="does-not-exist", mode="registry")

--- a/tests/test_syntax_serialize.py
+++ b/tests/test_syntax_serialize.py
@@ -1,0 +1,112 @@
+"""Tests for syntax serialize_block / describe_format methods."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+import pytest
+
+from hother.streamblocks.core.models import Block
+from hother.streamblocks.core.types import BaseContent, BaseMetadata, DetectionResult, ParseResult
+from hother.streamblocks.syntaxes.base import BaseSyntax
+from hother.streamblocks.syntaxes.delimiter import DelimiterFrontmatterSyntax, DelimiterPreambleSyntax
+from hother.streamblocks.syntaxes.markdown import MarkdownFrontmatterSyntax
+
+if TYPE_CHECKING:
+    from hother.streamblocks.core.models import BlockCandidate
+
+
+class _Meta(BaseMetadata):
+    block_type: Literal["note"] = "note"
+
+
+class _ParamMeta(BaseMetadata):
+    block_type: Literal["op"] = "op"
+    param_0: str = ""
+    param_1: str = ""
+
+
+class Note(Block[_Meta, BaseContent]):
+    """A note block."""
+
+
+class Op(Block[_ParamMeta, BaseContent]):
+    """An operation block with positional params."""
+
+
+def _note() -> Note:
+    return Note(metadata=_Meta(id="n1"), content=BaseContent(raw_content="hello"))
+
+
+def test_delimiter_preamble_serialize_roundtrips_through_parser() -> None:
+    syntax = DelimiterPreambleSyntax()
+    text = syntax.serialize_block(_note())
+    assert text == "!!n1:note\nhello\n!!end"
+
+
+def test_delimiter_preamble_serialize_emits_params() -> None:
+    syntax = DelimiterPreambleSyntax()
+    block = Op(metadata=_ParamMeta(id="o1", param_0="create", param_1="urgent"), content=BaseContent(raw_content="x"))
+    assert syntax.serialize_block(block) == "!!o1:op:create:urgent\nx\n!!end"
+
+
+def test_delimiter_frontmatter_serialize() -> None:
+    syntax = DelimiterFrontmatterSyntax()
+    text = syntax.serialize_block(_note())
+    assert text.startswith("!!start\n---\n")
+    assert "id: n1" in text
+    assert "block_type: note" in text
+    assert text.endswith("hello\n!!end")
+
+
+def test_markdown_serialize_with_info_string() -> None:
+    syntax = MarkdownFrontmatterSyntax(info_string="note")
+    text = syntax.serialize_block(_note())
+    assert text.startswith("```note\n---\n")
+    assert text.endswith("hello\n```")
+
+
+def test_markdown_serialize_without_info_string() -> None:
+    syntax = MarkdownFrontmatterSyntax()
+    text = syntax.serialize_block(_note())
+    assert text.startswith("```\n---\n")
+
+
+@pytest.mark.parametrize(
+    ("syntax", "needle"),
+    [
+        (DelimiterPreambleSyntax(), "Delimiter Preamble Syntax"),
+        (DelimiterFrontmatterSyntax(), "Delimiter Frontmatter Syntax"),
+        (MarkdownFrontmatterSyntax(info_string="note"), "Markdown Frontmatter Syntax"),
+        (MarkdownFrontmatterSyntax(), "[info_string]"),
+    ],
+)
+def test_describe_format_contains_expected_header(syntax: BaseSyntax, needle: str) -> None:
+    assert needle in syntax.describe_format()
+
+
+class _BareSyntax(BaseSyntax):
+    """Syntax that does not override serialize_block/describe_format."""
+
+    def detect_line(self, line: str, candidate: BlockCandidate | None) -> DetectionResult:
+        return DetectionResult()
+
+    def should_accumulate_metadata(self, candidate: BlockCandidate) -> bool:
+        return False
+
+    def extract_block_type(self, candidate: BlockCandidate) -> str | None:
+        return None
+
+    def parse_block(
+        self, candidate: BlockCandidate, block_class: type[Any] | None = None
+    ) -> ParseResult[BaseMetadata, BaseContent]:
+        return ParseResult(success=False, error="not implemented")
+
+
+def test_base_serialize_block_raises() -> None:
+    with pytest.raises(NotImplementedError, match="serialize_block"):
+        _BareSyntax().serialize_block(_note())
+
+
+def test_base_describe_format_default() -> None:
+    assert _BareSyntax().describe_format() == "_BareSyntax: no format description available."

--- a/uv.lock
+++ b/uv.lock
@@ -3017,6 +3017,7 @@ name = "streamblocks"
 version = "0.3.6"
 source = { editable = "." }
 dependencies = [
+    { name = "jinja2" },
     { name = "pydantic" },
     { name = "pydantic-ai" },
     { name = "pyyaml" },
@@ -3089,6 +3090,7 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'all-providers'", specifier = ">=1.38.0" },
     { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.38.0" },
     { name = "hother-cancelable", marker = "extra == 'examples'", specifier = ">=0.1.0" },
+    { name = "jinja2", specifier = ">=3.1.0" },
     { name = "loguru", marker = "extra == 'loguru'", specifier = ">=0.7.0" },
     { name = "openai", marker = "extra == 'all-providers'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },


### PR DESCRIPTION
Closes #44

## What
Adds a first-class `hother.streamblocks.prompts` package that generates LLM system prompts from a block `Registry` (and from individual block types) via Pydantic introspection, replacing hand-written prompt strings.

## API
- `Registry.to_prompt(include_examples=..., template_version=...)` — prompt documenting every registered block (syntax format, metadata fields, content format, serialized examples).
- `generate_block_prompt(block_class, syntax, ...)` — single block type.
- `Registry.register_template(...)` + Jinja2 templates (`registry.jinja2`, `single.jinja2`) for prompt A/B versioning.
- `Registry.registered_blocks` — read-only view of registered types.
- `BaseSyntax.serialize_block()` / `describe_format()` — non-abstract defaults; round-tripping overrides in the delimiter & markdown syntaxes.
- `Block.__examples__` + `get_examples()` / `add_example(s)` / markdown-file loading (YAML frontmatter, mtime-cached).
- `@parse_as_json` / `@parse_as_yaml` set a typed `__content_format__` marker (used by prompt generation; replaces fragile bytecode sniffing).

## Notes
- `jinja2` added as a core dependency; templates verified present in the built wheel.
- Additive only — built-in syntaxes/decorators keep their behavior.

## Verification
- `lefthook` pre-commit green (ruff + ruff-format + basedpyright, no `# type: ignore` / `# noqa`).
- `uv run pytest` green; new code at 100% coverage.
- `uv build` → wheel contains both `.jinja2` templates.