### PR TITLE
chore: code-quality review follow-up (DRY constant, processor refactor, packaging fixes)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,11 +306,6 @@ line-ending = "auto"
     "INP001",  # Implicit namespace package
     "PLC0415", # Import not at top-level (acceptable in tools)
 ]
-"src/hother/streamblocks/core/processor.py" = [
-    "PLR0912", # Too many branches
-    "PLR0915", # Too many statements
-    "C901",    # Too complex
-]
 "src/hother/streamblocks/core/models.py" = [
     "UP046",   # Type annotation can be modernized
     "PLC0415", # Import not at top-level (needed to avoid circular imports with syntaxes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/streamblocks/streamblocks"
-"Bug Tracker" = "https://github.com/streamblocks/streamblocks/issues"
-"Source" = "https://github.com/streamblocks/streamblocks"
-"Documentation" = "https://streamblocks.github.io/streamblocks/latest/"
+"Homepage" = "https://github.com/hotherio/streamblocks"
+"Bug Tracker" = "https://github.com/hotherio/streamblocks/issues"
+"Source" = "https://github.com/hotherio/streamblocks"
+"Documentation" = "https://streamblocks.hother.io/"
 
 # Optional dependencies
 [project.optional-dependencies]
@@ -42,6 +42,8 @@ all-providers = [
 # Enhanced logging
 structlog = ["structlog>=24.1.0"]
 loguru = ["loguru>=0.7.0"]
+# AG-UI protocol integration (see extensions/agui)
+agui = ["ag-ui-protocol>=0.1.0"]
 # Examples dependencies
 examples = ["streamblocks-examples", "hother-cancelable>=0.1.0"]
 

--- a/src/hother/streamblocks/core/block_state_machine.py
+++ b/src/hother/streamblocks/core/block_state_machine.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from hother.streamblocks.core._logger import StdlibLoggerAdapter
+from hother.streamblocks.core.constants import LIMITS
 from hother.streamblocks.core.models import BlockCandidate, ExtractedBlock
 from hother.streamblocks.core.registry import MetadataValidationFailureMode
 from hother.streamblocks.core.types import (
@@ -58,7 +59,7 @@ class BlockStateMachine:
         syntax: BaseSyntax,
         registry: Registry,
         *,
-        max_block_size: int = 1_048_576,
+        max_block_size: int = LIMITS.MAX_BLOCK_SIZE,
         emit_section_end_events: bool = True,
         logger: Logger | None = None,
     ) -> None:

--- a/src/hother/streamblocks/core/processor.py
+++ b/src/hother/streamblocks/core/processor.py
@@ -96,7 +96,7 @@ class ProcessorConfig:
 
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator, Callable
+    from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterator
 
     from hother.streamblocks.adapters.protocols import InputProtocolAdapter
     from hother.streamblocks.core._logger import Logger
@@ -196,43 +196,7 @@ class StreamBlockProcessor:
             ...     if isinstance(event, BlockErrorEvent):
             ...         print(f"Incomplete block: {event.reason}")
         """
-        events: list[TChunk | Event] = []
-
-        # Auto-detect adapter on first chunk
-        self._ensure_adapter(chunk, adapter)
-
-        # Emit original chunk (passthrough)
-        if self.config.emit_original_events and not isinstance(self._adapter, IdentityInputAdapter):
-            events.append(chunk)
-
-        # Extract text from chunk
-        if self._adapter is None:
-            raise AdapterNotConfiguredError(context="process_chunk")
-        text = cast("InputProtocolAdapter[Any]", self._adapter).extract_text(chunk)
-
-        if not text:
-            return events
-
-        # Log stream processing start on first chunk with text
-        if self._line_accumulator.line_number == 0 and not self._line_accumulator.has_pending_text:
-            self.logger.debug(
-                "stream_processing_started",
-                syntax=get_syntax_name(self.syntax),
-                lines_buffer=self.config.lines_buffer,
-                max_block_size=self.config.max_block_size,
-            )
-
-        # Emit text delta for real-time streaming
-        if self.config.emit_text_deltas:
-            events.append(self._create_text_delta_event(text))
-
-        # Process text through line accumulator and block state machine
-        for line_number, line in self._line_accumulator.add_text(text):
-            line_events = self._block_machine.process_line(line, line_number)
-            self._update_stats(line_events)
-            events.extend(line_events)
-
-        return events
+        return list(self._iter_chunk_outputs(chunk, adapter, context="process_chunk"))
 
     def finalize(self) -> list[Event]:
         """Finalize processing and flush any incomplete blocks.
@@ -260,22 +224,7 @@ class StreamBlockProcessor:
             ...     if isinstance(event, BlockErrorEvent):
             ...         print(f"Incomplete block: {event.reason}")
         """
-        events: list[Event] = []
-
-        # Process any remaining accumulated text as a final line
-        final_line = self._line_accumulator.finalize()
-        if final_line:
-            line_number, line = final_line
-            line_events = self._block_machine.process_line(line, line_number)
-            self._update_stats(line_events)
-            events.extend(line_events)
-
-        # Flush remaining candidates
-        flush_events = self._block_machine.flush(self._line_accumulator.line_number)
-        self._update_stats(flush_events)
-        events.extend(flush_events)
-
-        return events
+        return list(self._iter_finalize_outputs())
 
     def is_native_event(self, event: Any) -> bool:
         """Check if event is a native provider event (not a StreamBlocks event).
@@ -377,51 +326,11 @@ class StreamBlockProcessor:
             self._first_chunk_processed = True
 
         async for chunk in stream:
-            # Auto-detection on first chunk
-            self._ensure_adapter(chunk, None)
+            for output in self._iter_chunk_outputs(chunk, None, context="process_stream"):
+                yield output
 
-            # Emit original chunk (passthrough)
-            if self.config.emit_original_events and not isinstance(self._adapter, IdentityInputAdapter):
-                yield chunk
-
-            # Extract text from chunk
-            if self._adapter is None:
-                raise AdapterNotConfiguredError(context="process_stream")
-            text = cast("InputProtocolAdapter[Any]", self._adapter).extract_text(chunk)
-
-            if not text:
-                continue
-
-            # Log stream processing start on first chunk with text
-            if self._line_accumulator.line_number == 0 and not self._line_accumulator.has_pending_text:
-                self.logger.debug(
-                    "stream_processing_started",
-                    syntax=get_syntax_name(self.syntax),
-                    lines_buffer=self.config.lines_buffer,
-                    max_block_size=self.config.max_block_size,
-                )
-
-            # Emit text delta for real-time streaming
-            if self.config.emit_text_deltas:
-                yield self._create_text_delta_event(text)
-
-            # Process text through line accumulator and block state machine
-            for line_number, line in self._line_accumulator.add_text(text):
-                for event in self._block_machine.process_line(line, line_number):
-                    self._update_stats([event])
-                    yield event
-
-        # Process any remaining accumulated text as a final line
-        final_line = self._line_accumulator.finalize()
-        if final_line:
-            line_number, line = final_line
-            for event in self._block_machine.process_line(line, line_number):
-                self._update_stats([event])
-                yield event
-
-        # Flush remaining candidates at stream end
-        for event in self._block_machine.flush(self._line_accumulator.line_number):
-            self._update_stats([event])
+        # Process remaining text and flush incomplete blocks at stream end
+        for event in self._iter_finalize_outputs():
             yield event
 
     def _ensure_adapter(self, chunk: TChunk, adapter: InputProtocolAdapter[TChunk] | None) -> None:
@@ -446,6 +355,82 @@ class StreamBlockProcessor:
             self._adapter = IdentityInputAdapter()
 
         self._first_chunk_processed = True
+
+    def _iter_chunk_outputs(
+        self,
+        chunk: TChunk,
+        adapter: InputProtocolAdapter[TChunk] | None,
+        *,
+        context: str,
+    ) -> Iterator[TChunk | Event]:
+        """Yield the outputs produced by a single chunk.
+
+        Shared by the sync :meth:`process_chunk` (consumed via ``list()``) and the
+        async :meth:`process_stream` (re-yielded). Emits, in order: the original
+        chunk (passthrough), an optional TextDeltaEvent, then any block events from
+        the lines completed by this chunk's text.
+
+        Args:
+            chunk: Single chunk to process.
+            adapter: Optional adapter for text extraction; auto-detected on the
+                first chunk when not provided.
+            context: Caller name used in :class:`AdapterNotConfiguredError`.
+        """
+        # Auto-detect adapter on first chunk
+        self._ensure_adapter(chunk, adapter)
+
+        # Emit original chunk (passthrough)
+        if self.config.emit_original_events and not isinstance(self._adapter, IdentityInputAdapter):
+            yield chunk
+
+        # Extract text from chunk
+        if self._adapter is None:
+            raise AdapterNotConfiguredError(context=context)
+        text = cast("InputProtocolAdapter[Any]", self._adapter).extract_text(chunk)
+
+        if not text:
+            return
+
+        self._maybe_log_stream_start()
+
+        # Emit text delta for real-time streaming
+        if self.config.emit_text_deltas:
+            yield self._create_text_delta_event(text)
+
+        # Process text through line accumulator and block state machine
+        for line_number, line in self._line_accumulator.add_text(text):
+            line_events = self._block_machine.process_line(line, line_number)
+            self._update_stats(line_events)
+            yield from line_events
+
+    def _iter_finalize_outputs(self) -> Iterator[Event]:
+        """Yield the final line's events and rejection events for incomplete blocks.
+
+        Shared by :meth:`finalize` (consumed via ``list()``) and the tail of
+        :meth:`process_stream`.
+        """
+        # Process any remaining accumulated text as a final line
+        final_line = self._line_accumulator.finalize()
+        if final_line:
+            line_number, line = final_line
+            line_events = self._block_machine.process_line(line, line_number)
+            self._update_stats(line_events)
+            yield from line_events
+
+        # Flush remaining candidates
+        flush_events = self._block_machine.flush(self._line_accumulator.line_number)
+        self._update_stats(flush_events)
+        yield from flush_events
+
+    def _maybe_log_stream_start(self) -> None:
+        """Log the stream-start debug event once, on the first chunk with text."""
+        if self._line_accumulator.line_number == 0 and not self._line_accumulator.has_pending_text:
+            self.logger.debug(
+                "stream_processing_started",
+                syntax=get_syntax_name(self.syntax),
+                lines_buffer=self.config.lines_buffer,
+                max_block_size=self.config.max_block_size,
+            )
 
     def _create_text_delta_event(self, text: str) -> TextDeltaEvent:
         """Create a TextDeltaEvent with current block context."""

--- a/uv.lock
+++ b/uv.lock
@@ -3025,6 +3025,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+agui = [
+    { name = "ag-ui-protocol" },
+]
 all-providers = [
     { name = "anthropic" },
     { name = "google-genai" },
@@ -3085,6 +3088,7 @@ doc = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ag-ui-protocol", marker = "extra == 'agui'", specifier = ">=0.1.0" },
     { name = "anthropic", marker = "extra == 'all-providers'", specifier = ">=0.18.0" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.18.0" },
     { name = "google-genai", marker = "extra == 'all-providers'", specifier = ">=1.38.0" },
@@ -3101,7 +3105,7 @@ requires-dist = [
     { name = "structlog", marker = "extra == 'structlog'", specifier = ">=24.1.0" },
     { name = "textual", specifier = ">=6.1.0" },
 ]
-provides-extras = ["gemini", "openai", "anthropic", "all-providers", "structlog", "loguru", "examples"]
+provides-extras = ["gemini", "openai", "anthropic", "all-providers", "structlog", "loguru", "agui", "examples"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #46. ClickUp: 869dq7mh0.

Implements the justified subset of a code-quality review on the `streamblocks` package, plus two packaging fixes. Two atomic commits.

## Refactors (`refactor(core)`)
- **DRY**: `BlockStateMachine.max_block_size` default now references `LIMITS.MAX_BLOCK_SIZE` instead of a duplicated `1_048_576` literal.
- **Complexity**: `processor.py` `process_chunk`/`process_stream`/`finalize` collapsed onto three shared private helpers (`_iter_chunk_outputs`, `_iter_finalize_outputs`, `_maybe_log_stream_start`) — single source of truth for per-chunk output. The per-file ruff `PLR0912/PLR0915/C901` suppression is removed (functions are now under the mccabe-10 threshold).

## Fixes (`fix(packaging)`)
- Add missing `agui` optional-dependency extra — `extensions/agui` and the integration example already advertise `pip install "streamblocks[agui]"`, but no such extra was defined (`ag-ui-protocol` was dev-only).
- Correct project URLs: `streamblocks/streamblocks` → `hotherio/streamblocks`; docs → `https://streamblocks.hother.io/`.

## Verification
- `lefthook` pre-commit clean (ruff + basedpyright)
- 776 tests passing
- AG-UI integration example runs; `agui` extra resolves

## Deliberately out of scope (per review analysis)
- #2 adapter `isinstance` coupling (redundant with `emit_original_events`)
- #4 `Block` ExampleManager extraction (not a god class)
- #6 `utils.get_syntax_name` removal (would increase repetition)
- #3 registry test fixture / #7 AG-UI table consolidation — held as separable
- Example-runner output assertion (silent-zero-extraction) — tracked as F3 for its own PR