### PR TITLE
ci: pin semantic-release workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -27,19 +27,19 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Import GPG key
         id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
         with:
           gpg_private_key: ${{ secrets.HOTHER_BOT_GPG_KEY }}
           passphrase: ${{ secrets.HOTHER_BOT_GPG_PASSPHRASE }}
@@ -83,7 +83,7 @@ jobs:
       - name: Generate release notes for current version
         id: release-notes
         if: steps.release.outputs.released == 'true'
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           config: cliff.toml
           args: -vv --latest --strip header
@@ -92,7 +92,7 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.release.outputs.released == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
 
       - name: Generate asset checksums
         if: steps.release.outputs.released == 'true'
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.release.outputs.tag }}
 


### PR DESCRIPTION
The org now enforces full-length SHA pinning for GitHub Actions. The Semantic Release workflow still referenced six actions by tag, so it fails immediately ("all actions must be pinned to a full-length commit SHA") and no release can run.

Pins the six remaining refs in `semantic-release.yml` to commit SHAs (version kept in trailing `# vN` comments), matching the convention already used across the other workflows:
- `actions/create-github-app-token@…d72941d` # v1
- `actions/checkout@…34e1148` # v4 (×2)
- `actions/setup-python@…a26af69` # v5
- `crazy-max/ghaction-import-gpg@…e89d409` # v6
- `orhun/git-cliff-action@…f50e115` # v4
- `pypa/gh-action-pypi-publish@…cef2210` # release/v1

Once merged, the push to `main` will trigger Semantic Release, which will cut **v0.4.0** (minor — backlog since v0.3.6 includes `feat(prompts)` #45).