### PR TITLE
ci: bump release workflow actions to Node 24 versions

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -27,19 +27,19 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Import GPG key
         id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         with:
           gpg_private_key: ${{ secrets.HOTHER_BOT_GPG_KEY }}
           passphrase: ${{ secrets.HOTHER_BOT_GPG_PASSPHRASE }}
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.release.outputs.tag }}
 


### PR DESCRIPTION
Follow-up to #51. The v0.4.0 release logs flagged that four actions in the release workflow still run on Node 20, deprecated by GitHub (forced to Node 24 from 2026-06-16; removed from runners 2026-09-16).

Bumps each to its Node 24 major, re-pinned to a full commit SHA (verified using: node24 in each action.yml):

- actions/create-github-app-token v1 -> v3 (bcd2ba4)
- actions/checkout v4 -> v6 (df4cb1c, x2)
- actions/setup-python v5 -> v6 (a309ff8)
- crazy-max/ghaction-import-gpg v6 -> v7 (2dc316d)

git-cliff-action and gh-action-pypi-publish are container-based (not Node), so unaffected and left as-is. The create-github-app-token v1->v3 jump keeps the same app-id/private-key inputs and token output, so no other edits needed.

All uses: remain SHA-pinned (satisfies org SHA-pinning policy).